### PR TITLE
Fix complilation issues with latest ffmpeg + cleanup #include dependencies in video/ 

### DIFF
--- a/src/video/ffmpegstream.cpp
+++ b/src/video/ffmpegstream.cpp
@@ -1,5 +1,10 @@
 #include "ffmpegstream.h"
 
+extern "C" {
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+};
+
 namespace Impacto {
 namespace Video {
 

--- a/src/video/ffmpegstream.h
+++ b/src/video/ffmpegstream.h
@@ -1,13 +1,13 @@
 #pragma once
 
-extern "C" {
-#include <libavformat/avformat.h>
-#include <libavutil/imgutils.h>
-#include <libavutil/time.h>
-};
+#include "../impacto.h"
 
 #include <queue>
-#include "../impacto.h"
+
+struct AVFrame;
+struct AVPacket;
+struct AVCodecContext;
+struct AVStream;
 
 namespace Impacto {
 namespace Video {

--- a/src/video/videoplayer.cpp
+++ b/src/video/videoplayer.cpp
@@ -1,8 +1,18 @@
 #include "videoplayer.h"
+#include "ffmpegstream.h"
+
 #include "../log.h"
-#include <utility>
 #include "../profile/game.h"
-#include "../audio/audiosystem.h"
+#include "../renderer2d.h"
+#include "../io/inputstream.h"
+
+extern "C" {
+#include <libavcodec/avcodec.h>
+#include <libavutil/time.h>
+#include <libswscale/swscale.h>
+#include <libswresample/swresample.h>
+#include <libavformat/avformat.h>
+};
 
 namespace Impacto {
 namespace Video {
@@ -140,10 +150,9 @@ void VideoPlayer::Play(Io::InputStream* stream, bool looping, bool alpha) {
                                                  : AVDISCARD_ALL;
   }
 
-  AVCodec* codec = NULL;
   // Find and open the video codec
   if (videoStreamId != AVERROR_STREAM_NOT_FOUND) {
-    codec = avcodec_find_decoder(videoStream->codecpar->codec_id);
+    const auto codec = avcodec_find_decoder(videoStream->codecpar->codec_id);
     if (codec == NULL) {
       ImpLog(LL_Error, LC_Video, "Unsupported codec!\n");
       return;
@@ -161,7 +170,7 @@ void VideoPlayer::Play(Io::InputStream* stream, bool looping, bool alpha) {
 
   // Find and open the audio codec
   if (audioStreamId != AVERROR_STREAM_NOT_FOUND) {
-    codec = avcodec_find_decoder(audioStream->codecpar->codec_id);
+    const auto codec = avcodec_find_decoder(audioStream->codecpar->codec_id);
     if (codec == NULL) {
       ImpLog(LL_Error, LC_Video, "Unsupported codec!\n");
       return;

--- a/src/video/videoplayer.h
+++ b/src/video/videoplayer.h
@@ -1,25 +1,29 @@
 #pragma once
 
-extern "C" {
-#include <libavformat/avformat.h>
-#include <libavutil/imgutils.h>
-#include <libavutil/time.h>
-#include <libswscale/swscale.h>
-#include <libswresample/swresample.h>
-};
-
-#include <queue>
-
-#include "ffmpegstream.h"
 #include "../impacto.h"
-#include "../io/inputstream.h"
-#include "../log.h"
 #include "yuvframe.h"
-#include "../texture/texture.h"
-#include "../renderer2d.h"
+#include "alc.h"
+#include "al.h"
+
+// Forward Decl
+struct SwrContext;
+struct SwsContext;
+struct AvMediaType;
+struct AVFormatContext;
+struct AVIOContext;
+enum AVMediaType;
+
+namespace Impacto {
+namespace Io {
+class InputStream;
+}
+}  // namespace Impacto
 
 namespace Impacto {
 namespace Video {
+
+// Forward Decl
+class FFmpegStream;
 
 class Clock {
  public:

--- a/src/video/videosystem.cpp
+++ b/src/video/videosystem.cpp
@@ -1,6 +1,5 @@
 #include "videosystem.h"
 #include "../log.h"
-#include <utility>
 
 namespace Impacto {
 namespace Video {

--- a/src/video/videosystem.h
+++ b/src/video/videosystem.h
@@ -2,8 +2,6 @@
 
 #include "videoplayer.h"
 #include "../impacto.h"
-#include "../io/inputstream.h"
-#include "../log.h"
 
 namespace Impacto {
 namespace Video {

--- a/src/video/yuvframe.cpp
+++ b/src/video/yuvframe.cpp
@@ -1,10 +1,6 @@
 #include "yuvframe.h"
 
-#include <string.h>
-
 #include <glad/glad.h>
-
-#include "../log.h"
 
 namespace Impacto {
 

--- a/src/video/yuvframe.h
+++ b/src/video/yuvframe.h
@@ -1,9 +1,8 @@
 #pragma once
 
 #include "../impacto.h"
-#include <vector>
-#include "../io/inputstream.h"
-#include "../texture/texture.h"
+
+#include <glm/glm.hpp>
 
 namespace Impacto {
 


### PR DESCRIPTION
The build dependency download script doesn't discriminate package versions, so when I synced latest, I pulled down ffmpeg ver 5.0.2#2. Looks like In the last couple years or so ffmpeg moved around a variety of functions used by the videoplayer and const'd their API. (https://github.com/FFmpeg/FFmpeg/commit/626535f6a169e2d821b969e0ea77125ba7482113)

Whilst working to get it compiling I also did some header dependency clean-up. 