### PR TITLE
Fixes for setup + build

### DIFF
--- a/doc/ubuntu1804_build.md
+++ b/doc/ubuntu1804_build.md
@@ -32,6 +32,9 @@ cmake .
 make
 popd
 
+# Executable expects the shaders dir to be nearby
+cp -r src/shaders .
+
 # Build impacto
 LIBATRAC9DIR=vendor/LibAtrac9 cmake .
 make

--- a/src/io/filemeta.h
+++ b/src/io/filemeta.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <cstdint>
 
 namespace Impacto {
 namespace Io {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,7 @@
 
 #include "log.h"
 #include "game.h"
+#include "util.h"
 
 #include "io/physicalfilestream.h"
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -53,6 +53,7 @@ int main(int argc, char* argv[]) {
   std::string profileName;
   profileName.resize(stream->Meta.Size, '\0');
   profileName.resize(stream->Read(&profileName[0], stream->Meta.Size));
+  TrimString(profileName);
 
 #ifdef EMSCRIPTEN
   // Emscripten's EGL requests a window framebuffer with antialiasing by default

--- a/src/util.h
+++ b/src/util.h
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <SDL_stdinc.h>
 #include <string>
+#include <cctype>
 
 // TODO own _malloca for gcc
 
@@ -156,6 +157,20 @@ inline bool StringEndsWithCi(std::string const& str,
   if (str.length() < ending.length()) return false;
   return 0 == SDL_strcasecmp(str.c_str() + str.length() - ending.length(),
                              ending.c_str());
+}
+
+// Trim whitespace in-place
+inline void TrimString(std::string& str) {
+  // from the left
+  str.erase(str.begin(),
+            std::find_if(str.begin(), str.end(),
+                         [](unsigned char c) { return !std::isspace(c); }));
+
+  // from the right
+  str.erase(std::find_if(str.rbegin(), str.rend(),
+                         [](unsigned char c) { return !std::isspace(c); })
+                .base(),
+            str.end());
 }
 
 }  // namespace Impacto


### PR DESCRIPTION
Added a few changes to fix issues I and some others had while cloning and building the project.

- added step to copy src/shaders to the root directory in the Linux script, which was missing on execution
- explicitly included <cstdint> in src/io/filemeta.h since compilation was failing due to declared uint64_t etc.
- added logic to trim the whitespace from the profile define in profile.txt, since appended newlines were causing the wrong file to be looked for