### PR TITLE
Quick dialog pages correction

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -282,7 +282,8 @@ void Render() {
 
       switch (DrawComponents[i]) {
         case DrawComponentType::Text: {
-          DialoguePages[0].Render();
+          for (int i = 0; i < Profile::Dialogue::PageCount; i++)
+            DialoguePages[i].Render();
           break;
         }
         case DrawComponentType::Main: {

--- a/src/vm/inst_dialogue.cpp
+++ b/src/vm/inst_dialogue.cpp
@@ -79,6 +79,7 @@ VmInstruction(InstMesSetID) {
                  "STUB instruction MesSetID(type: SetSavePoint1, "
                  "savePointId: %i, arg1: %i)\n",
                  savePointId, dialoguePageId);
+      thread->DialoguePageId = dialoguePageId;
     } break;
     case 2: {  // SetPage
       PopExpression(dialoguePageId);
@@ -116,7 +117,7 @@ VmInstruction(InstMes) {
   if (DialoguePages[thread->DialoguePageId].FadeAnimation.IsOut() &&
       GetFlag(thread->DialoguePageId + SF_MESWINDOW0OPENFL)) {
     DialoguePages[thread->DialoguePageId].Mode =
-        (DialoguePageMode)ScrWork[SW_MESMODE0];
+        (DialoguePageMode)ScrWork[thread->DialoguePageId * 10 + SW_MESMODE0];
     DialoguePages[thread->DialoguePageId].FadeAnimation.StartIn(true);
   }
 
@@ -276,8 +277,8 @@ VmInstruction(InstMessWindow) {
       break;
     case 1:  // ShowCurrent
       if (!currentPage->FadeAnimation.IsIn()) {
-        currentPage->Mode =
-            (DialoguePageMode)ScrWork[SW_MESMODE0];  // Only for page 0 for now
+        currentPage->Mode = (DialoguePageMode)
+            ScrWork[thread->DialoguePageId * 10 + SW_MESMODE0];
         currentPage->FadeAnimation.StartIn(true);
         SetFlag(thread->DialoguePageId + SF_MESWINDOW0OPENFL, 1);
       }


### PR DESCRIPTION
Should fix a floating text on CCs, example in AA06, but mescls needs to be implemented to fix the clearing of the page. 