### PR TITLE
Generic CMake Unix Platform Improvement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -636,7 +636,7 @@ if (NX OR EMSCRIPTEN)
     set(IMPACTO_DISABLE_DX9 ON)
 endif ()
 
-if (APPLE OR LINUX)
+if (UNIX AND NOT CYGWIN)
     set(IMPACTO_DISABLE_DX9 ON)
 endif ()
 


### PR DESCRIPTION
This simple change allows coverage of Linux, Mac, the BSDs and any other platform that's not Windows. Cygwin counts as "Unix" but can use Direct3D9, so make an exception there. See here: https://cmake.org/cmake/help/latest/variable/UNIX.html