### PR TITLE
Enhancement: Build GLM v1.0.2+ Module directly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -327,6 +327,13 @@ set(Impacto_Src
         vendor/pugixml/src/pugixml.cpp
 )
 
+if (IMPACTO_MODULE_GLM)
+    set(Impacto_Src
+        ${Impacto_Src}
+        vendor/glm/glm/glm.cppm
+    )
+endif ()
+
 set(Impacto_Header
         src/impacto.h
         src/log.h
@@ -696,7 +703,12 @@ if (WIN32)
 endif ()
 
 find_package(Libatrac9 REQUIRED)
-find_package(glm REQUIRED)
+
+if (IMPACTO_MODULE_GLM)
+    find_package(glm CONFIG REQUIRED)
+else ()
+    find_package(glm REQUIRED)
+endif ()
 
 if (NX) # avoid CMAKE_DL_LIBS for NX
     set(Impacto_Libs
@@ -813,7 +825,7 @@ else ()
             list(APPEND Impacto_Libs
                     glm::glm
             )
-        elseif (NOT APPLE) # If we don't do this it decides to link glm as a library on macOS for some reason
+        elseif (NOT APPLE AND NOT DEFINED IMPACTO_MODULE_GLM) # If we don't do this it decides to link glm as a library on macOS for some reason
             list(APPEND Impacto_Libs
                     glm
             )
@@ -1004,7 +1016,11 @@ target_link_libraries(impacto PUBLIC ${Impacto_Libs})
 
 # compiler/dependency configuration
 
-set_property(TARGET impacto PROPERTY CXX_STANDARD 17)
+if (IMPACTO_MODULE_GLM)
+    set_property(TARGET impacto PROPERTY CXX_STANDARD 20)
+else ()
+    set_property(TARGET impacto PROPERTY CXX_STANDARD 17)
+endif()
 
 if (EMSCRIPTEN)
     set(CMAKE_EXECUTABLE_SUFFIX ".html")


### PR DESCRIPTION
This [commit ](https://github.com/g-truc/glm/commit/da9a21d7e3a2a3a32354a7d9da362d5738b113b6)introduced building glm as a module but is only available on the current master branch.

My proposed changes allow for backwards compatibility with older versions of the library and requires passing `-DIMPACTO_MODULE_GLM=ON` to cmake to enable it. I haven't fully tested this and it's possible it will add some bugs, but it does build successfully with Clang 17 on FreeBSD 14.0.