### PR TITLE
Bugfix/cclcc saveload

### DIFF
--- a/src/data/savesystem.cpp
+++ b/src/data/savesystem.cpp
@@ -24,8 +24,12 @@ void SaveMemory() {
   if (Implementation) Implementation->SaveMemory();
 }
 
-void LoadMemory(SaveType type, int id) {
-  if (Implementation) Implementation->LoadMemory(type, id);
+void LoadEntry(SaveType type, int id) {
+  if (Implementation) Implementation->LoadEntry(type, id);
+}
+
+void LoadMemoryNew(LoadProcess load) {
+  if (Implementation) Implementation->LoadMemoryNew(load);
 }
 
 void FlushWorkingSaveEntry(SaveType type, int id) {

--- a/src/data/savesystem.h
+++ b/src/data/savesystem.h
@@ -25,6 +25,8 @@ enum SaveError {
 
 enum SaveType { SaveFull = 0, SaveQuick = 1 };
 
+enum LoadProcess { LoadVars = 0, LoadThread = 1 };
+
 int constexpr MaxSaveEntries = 48;
 
 uint8_t const Flbit[] = {1, 2, 4, 8, 0x10, 0x20, 0x40, 0x80};
@@ -66,7 +68,8 @@ class SaveSystemBase {
  public:
   virtual SaveError MountSaveFile() = 0;
   virtual void SaveMemory() = 0;
-  virtual void LoadMemory(SaveType type, int id) = 0;
+  virtual void LoadEntry(SaveType type, int id) = 0;
+  virtual void LoadMemoryNew(LoadProcess){};
   virtual void FlushWorkingSaveEntry(SaveType type, int id) = 0;
   virtual void WriteSaveFile() = 0;
   virtual uint32_t GetSavePlayTime(SaveType type, int id) = 0;
@@ -104,7 +107,8 @@ void Init();
 
 SaveError MountSaveFile();
 void SaveMemory();
-void LoadMemory(SaveType type, int id);
+void LoadEntry(SaveType type, int id);
+void LoadMemoryNew(LoadProcess process);
 void FlushWorkingSaveEntry(SaveType type, int id);
 void WriteSaveFile();
 uint32_t GetSavePlayTime(SaveType type, int id);

--- a/src/games/cclcc/savesystem.h
+++ b/src/games/cclcc/savesystem.h
@@ -26,7 +26,8 @@ class SaveSystem : public SaveSystemBase {
  public:
   SaveError MountSaveFile() override;
   void SaveMemory() override;
-  void LoadMemory(SaveType type, int id) override;
+  void LoadEntry(SaveType type, int id) override;
+  void LoadMemoryNew(LoadProcess load) override;
   void FlushWorkingSaveEntry(SaveType type, int id) override;
   void WriteSaveFile() override;
   uint32_t GetSavePlayTime(SaveType type, int id) override;

--- a/src/games/cclcc/savesystem.h
+++ b/src/games/cclcc/savesystem.h
@@ -3,6 +3,7 @@
 #include "../../data/savesystem.h"
 #include "../../texture/texture.h"
 #include "../../spritesheet.h"
+#include <optional>
 
 namespace Impacto {
 namespace CCLCC {
@@ -55,6 +56,7 @@ class SaveSystem : public SaveSystemBase {
   uint8_t MessageFlags[10000];
   bool EVFlags[1200];
   uint8_t BGMFlags[200];
+  std::optional<SaveFileEntry> WorkingSaveEntry;
 };
 
 }  // namespace CCLCC

--- a/src/games/chlcc/savesystem.cpp
+++ b/src/games/chlcc/savesystem.cpp
@@ -330,7 +330,7 @@ void SaveSystem::SaveMemory() {
   }
 }
 
-void SaveSystem::LoadMemory(SaveType type, int id) {
+void SaveSystem::LoadEntry(SaveType type, int id) {
   SaveFileEntry* entry = 0;
   switch (type) {
     case SaveQuick:

--- a/src/games/chlcc/savesystem.h
+++ b/src/games/chlcc/savesystem.h
@@ -19,7 +19,7 @@ class SaveSystem : public SaveSystemBase {
  public:
   SaveError MountSaveFile() override;
   void SaveMemory() override;
-  void LoadMemory(SaveType type, int id) override;
+  void LoadEntry(SaveType type, int id) override;
   void FlushWorkingSaveEntry(SaveType type, int id) override;
   void WriteSaveFile() override;
   uint32_t GetSavePlayTime(SaveType type, int id) override;

--- a/src/games/mo6tw/savesystem.cpp
+++ b/src/games/mo6tw/savesystem.cpp
@@ -426,7 +426,7 @@ void SaveSystem::SaveMemory() {
   }
 }
 
-void SaveSystem::LoadMemory(SaveType type, int id) {
+void SaveSystem::LoadEntry(SaveType type, int id) {
   SaveFileEntry* entry = 0;
   switch (type) {
     case SaveQuick:

--- a/src/games/mo6tw/savesystem.h
+++ b/src/games/mo6tw/savesystem.h
@@ -19,7 +19,7 @@ class SaveSystem : public SaveSystemBase {
  public:
   SaveError MountSaveFile() override;
   void SaveMemory() override;
-  void LoadMemory(SaveType type, int id) override;
+  void LoadEntry(SaveType type, int id) override;
   void FlushWorkingSaveEntry(SaveType type, int id) override;
   void WriteSaveFile() override;
   uint32_t GetSavePlayTime(SaveType type, int id) override;

--- a/src/vm/inst_misc.cpp
+++ b/src/vm/inst_misc.cpp
@@ -436,11 +436,8 @@ VmInstruction(InstLoadData) {
     case 0:
     case 10: {
       PopExpression(arg1);
-      if (Profile::Vm::GameInstructionSet == +InstructionSet::CC) {
-        PopExpression(arg2);
-        SaveSystem::LoadMemory(static_cast<SaveSystem::SaveType>(arg1), arg2);
-      }
-
+      PopExpression(arg2);
+      SaveSystem::LoadEntry(static_cast<SaveSystem::SaveType>(arg1), arg2);
       ImpLogSlow(LL_Warning, LC_VMStub,
                  "STUB instruction LoadData(type: %i, arg1: %i)\n", type, arg1);
     } break;
@@ -451,11 +448,12 @@ VmInstruction(InstLoadData) {
                  type);
       break;
   }
+  SaveSystem::LoadMemoryNew(static_cast<SaveSystem::LoadProcess>(type));
 }
 VmInstruction(InstLoadDataOld) {
   StartInstruction;
   PopExpression(arg1);
-  SaveSystem::LoadMemory(SaveSystem::SaveFull, arg1);
+  SaveSystem::LoadEntry(SaveSystem::SaveFull, arg1);
   if (ScrWork[SW_MESWINDOW_COLOR] == 0) ScrWork[SW_MESWINDOW_COLOR] = 0xFFFFFF;
 }
 VmInstruction(InstTitleMenu) {


### PR DESCRIPTION
Should fix the loaded from saves being broken. Not sure why there's so many threads created when you repeatedly load though, maybe MAINTHDP ScrWork needs to get reset or something. Potential source of crash if you repeatedly load