### PR TITLE
Fixed "vfs.js" typo in `getting_started.md`

### DIFF
--- a/doc/getting_started.md
+++ b/doc/getting_started.md
@@ -29,7 +29,7 @@ The following profiles are currently available:
 * **modelviewer** - A viewer for 3D models from Robotics;Notes Elite
 * **modelviewer-dash** - A viewer for 3D models from Robotics;Notes DaSH
 
-For the list of required game resource files refer to the `vfs.js` file located in desired game profile directory. The resource files should be placed in `/games/<profile_name>/gamedata/` directory.
+For the list of required game resource files refer to the `vfs.lua` file located in desired game profile directory. The resource files should be placed in `/games/<profile_name>/gamedata/` directory.
 
 ## General engine information
 To get an overall understanding of how the original Mages. engine functions please refer to https://committeeofzero.gitbooks.io/mages-engine-compendium/content/


### PR DESCRIPTION
Currently in the `getting_started.md` file, it says that "For the list of required game resource files refer to the vfs.js file located in desired game profile directory". However, the files are actually named vfs.lua, this pull request fixes the error to avoid confusion