### PR TITLE
Load spritesheets concurrently

### DIFF
--- a/src/profile/sprites.cpp
+++ b/src/profile/sprites.cpp
@@ -46,7 +46,8 @@ void LoadSpritesheets() {
       Window->Shutdown();
     }
 
-    futures.emplace_back(std::tuple(name, std::async(std::launch::async, LoadTexture, stream, name)));
+    futures.emplace_back(std::tuple(
+        name, std::async(std::launch::async, LoadTexture, stream, name)));
 
     Pop();
   }


### PR DESCRIPTION
This PR loads Spritesheets in parallel on different threads using `std::async`.

I was annoyed by the slow startup times when testing things, especially in debug mode.
After some profiling I found that ~40% of the time was spent in stb_image.
By splitting this work over multiple threads the time-to-menu is significantly faster with a relatively simple change.
Loading sprite sheets for CC;LCC in Debug mode went from ~22s to ~13s for me (Ryzen 7 5800X)

There are no doubt more optimal ways to squeeze out more performance but my main goal was to speed up iteration time during development by picking up some low hanging fruit, and this seems to be a good start.

CPU utilization before:
![image](https://github.com/user-attachments/assets/b000230c-a4e6-4d24-8174-0b0c43b2167d)

CPU utilization after:
![image](https://github.com/user-attachments/assets/bf1b3839-0f2b-493d-92bf-265b02c486a7)
