### PR TITLE
Slow down C;C(LCC) backlog fade when opened from menu

### DIFF
--- a/profiles/cc/hud/backlogmenu.lua
+++ b/profiles/cc/hud/backlogmenu.lua
@@ -27,8 +27,10 @@ root.BacklogMenu = {
     RenderingBounds = { X = 194, Y = 121, Width = 1531, Height = 868 },
     EntryYPadding = 26,
 
-    FadeInDuration = 0.2,
-    FadeOutDuration = 0.2,
+    FadeInDuration = 0.5,
+    FadeOutDuration = 0.5,
+    FadeInDirectDuration = 0.25,
+    FadeOutDirectDuration = 0.25,
 
     ScrollingSpeed = 900,
     MinHoldTime = 0.5,

--- a/profiles/cclcc/hud/backlogmenu.lua
+++ b/profiles/cclcc/hud/backlogmenu.lua
@@ -27,8 +27,10 @@ root.BacklogMenu = {
     RenderingBounds = { X = 194, Y = 121, Width = 1531, Height = 868 },
     EntryYPadding = 26,
 
-    FadeInDuration = 0.2,
-    FadeOutDuration = 0.2,
+    FadeInDuration = 0.5,
+    FadeOutDuration = 0.5,
+    FadeInDirectDuration = 0.25,
+    FadeOutDirectDuration = 0.25,
 
     ScrollingSpeed = 900,
     MinHoldTime = 0.5,

--- a/profiles/mo6tw/hud/backlogmenu.lua
+++ b/profiles/mo6tw/hud/backlogmenu.lua
@@ -1,7 +1,6 @@
 root.BacklogMenu = {
     Type = BacklogMenuType.MO6TW,
     DrawType = DrawComponentType.ExtrasScenes,
-    NametagLocation = BacklogNametagLocation.AboveLeftOfText;
     BacklogBackgroundSprite = "BacklogBackground",
     EntryHighlightSprite = "EntryHighlight",
     EntryHighlightLocation = EntryHighlightLocationType.BottomLeftOfEntry,

--- a/src/games/cc/backlogmenu.cpp
+++ b/src/games/cc/backlogmenu.cpp
@@ -5,6 +5,7 @@
 #include "../../ui/widgets/cc/backlogentry.h"
 #include "../../profile/ui/backlogmenu.h"
 #include "../../profile/games/cc/backlogmenu.h"
+#include "../../profile/scriptvars.h"
 
 namespace Impacto {
 namespace UI {
@@ -14,6 +15,7 @@ using namespace Impacto::UI::CC;
 using namespace Impacto::Profile::BacklogMenu;
 using namespace Impacto::Profile::CC::BacklogMenu;
 using namespace Impacto::UI::Widgets::CC;
+using namespace Impacto::Profile::ScriptVars;
 
 void BacklogMenu::MenuButtonOnClick(Widgets::BacklogEntry* target) {
   if (target->AudioId != -1) {
@@ -21,6 +23,34 @@ void BacklogMenu::MenuButtonOnClick(Widgets::BacklogEntry* target) {
   } else {
     Audio::Channels[Audio::AC_REV]->Play("sysse", 4, false, 0.0f);
   }
+}
+
+void BacklogMenu::Show() {
+  if (State == Hidden) {
+    if (ScrWork[SW_SYSSUBMENUCT] != 32) {
+      FadeAnimation.DurationIn = FadeInDuration;
+      FadeAnimation.DurationOut = FadeOutDuration;
+    } else {
+      FadeAnimation.DurationIn = FadeInDirectDuration;
+      FadeAnimation.DurationOut = FadeOutDirectDuration;
+    }
+  }
+
+  UI::BacklogMenu::Show();
+}
+
+void BacklogMenu::Hide() {
+  if (State == Shown) {
+    if (ScrWork[SW_SYSSUBMENUCT] != 0) {
+      FadeAnimation.DurationIn = FadeInDuration;
+      FadeAnimation.DurationOut = FadeOutDuration;
+    } else {
+      FadeAnimation.DurationIn = FadeInDirectDuration;
+      FadeAnimation.DurationOut = FadeOutDirectDuration;
+    }
+  }
+
+  UI::BacklogMenu::Hide();
 }
 
 void BacklogMenu::Render() {

--- a/src/games/cc/backlogmenu.cpp
+++ b/src/games/cc/backlogmenu.cpp
@@ -27,7 +27,7 @@ void BacklogMenu::MenuButtonOnClick(Widgets::BacklogEntry* target) {
 
 void BacklogMenu::Show() {
   if (State == Hidden) {
-    if (ScrWork[SW_SYSSUBMENUCT] != 32) {
+    if (ScrWork[SW_SYSMENUALPHA] == 0x100) {
       FadeAnimation.DurationIn = FadeInDuration;
       FadeAnimation.DurationOut = FadeOutDuration;
     } else {
@@ -41,7 +41,7 @@ void BacklogMenu::Show() {
 
 void BacklogMenu::Hide() {
   if (State == Shown) {
-    if (ScrWork[SW_SYSSUBMENUCT] != 0) {
+    if (ScrWork[SW_SYSMENUALPHA] == 0x100) {
       FadeAnimation.DurationIn = FadeInDuration;
       FadeAnimation.DurationOut = FadeOutDuration;
     } else {

--- a/src/games/cc/backlogmenu.h
+++ b/src/games/cc/backlogmenu.h
@@ -10,8 +10,10 @@ namespace CC {
 
 class BacklogMenu : public UI::BacklogMenu {
  public:
-  void Render();
-  void MenuButtonOnClick(Widgets::BacklogEntry* target);
+  void Show() override;
+  void Hide() override;
+  void Render() override;
+  void MenuButtonOnClick(Widgets::BacklogEntry* target) override;
 
  private:
   Widgets::CC::BacklogEntry* CreateBacklogEntry(

--- a/src/profile/games/cc/backlogmenu.cpp
+++ b/src/profile/games/cc/backlogmenu.cpp
@@ -21,6 +21,9 @@ void Configure() {
   MenuMaskSprite = EnsureGetMemberSprite("MenuMask");
   BacklogMaskSheet = EnsureGetMemberSpriteSheet("BacklogMask");
 
+  FadeInDirectDuration = EnsureGetMemberFloat("FadeInDirectDuration");
+  FadeOutDirectDuration = EnsureGetMemberFloat("FadeOutDirectDuration");
+
   auto drawType = Game::DrawComponentType::_from_integral_unchecked(
       EnsureGetMemberInt("DrawType"));
 

--- a/src/profile/games/cc/backlogmenu.h
+++ b/src/profile/games/cc/backlogmenu.h
@@ -20,6 +20,9 @@ inline glm::vec2 BacklogControlsPosition;
 inline Sprite MenuMaskSprite;
 inline SpriteSheet BacklogMaskSheet;
 
+inline float FadeInDirectDuration;
+inline float FadeOutDirectDuration;
+
 }  // namespace BacklogMenu
 }  // namespace CC
 }  // namespace Profile

--- a/src/vm/inst_dialogue.cpp
+++ b/src/vm/inst_dialogue.cpp
@@ -226,6 +226,7 @@ VmInstruction(InstMesRev) {
   PopUint8(type);
   switch (type) {
     case 0:  // DispInit
+      UI::BacklogMenuPtr->Show();
       ImpLogSlow(LL_Warning, LC_VMStub,
                  "STUB instruction SetMesModeFormat(type: DispInit)\n");
       break;

--- a/src/vm/inst_dialogue.cpp
+++ b/src/vm/inst_dialogue.cpp
@@ -226,7 +226,6 @@ VmInstruction(InstMesRev) {
   PopUint8(type);
   switch (type) {
     case 0:  // DispInit
-      UI::BacklogMenuPtr->Show();
       ImpLogSlow(LL_Warning, LC_VMStub,
                  "STUB instruction SetMesModeFormat(type: DispInit)\n");
       break;


### PR DESCRIPTION
The C;C(LCC) backlog fade animation is twice as slow when opened from the menu as opposed to opening it directly. This PR implements such functionality.