### PR TITLE
MO6TW regression fixes

### DIFF
--- a/profiles/mo6tw/dialogue.lua
+++ b/profiles/mo6tw/dialogue.lua
@@ -26,7 +26,7 @@ root.Sprites["ADVBoxDecoration"] = {
 root.Dialogue = {
     TipsBounds = { X = 394, Y = 263, Width = 820, Height = 370 },
     TipsColorIndex = 0,
-    REVBounds = { X = 84, Y = 111, Width = 1072, Height = 602 },
+    REVBounds = { X = 163, Y = 83, Width = 960, Height = 590 },
     REVNameFontSize = 24,
     REVColor = 0,
     REVNameColor = 24,

--- a/profiles/mo6tw/dialogue.lua
+++ b/profiles/mo6tw/dialogue.lua
@@ -26,7 +26,7 @@ root.Sprites["ADVBoxDecoration"] = {
 root.Dialogue = {
     TipsBounds = { X = 394, Y = 263, Width = 820, Height = 370 },
     TipsColorIndex = 0,
-    REVBounds = { X = 0, Y = 0, Width = 960, Height = 400 },
+    REVBounds = { X = 84, Y = 111, Width = 1072, Height = 602 },
     REVNameFontSize = 24,
     REVColor = 0,
     REVNameColor = 24,

--- a/profiles/mo6tw/hud/backlogmenu.lua
+++ b/profiles/mo6tw/hud/backlogmenu.lua
@@ -1,20 +1,27 @@
 root.BacklogMenu = {
     Type = BacklogMenuType.MO6TW,
     DrawType = DrawComponentType.ExtrasScenes,
+
     BacklogBackgroundSprite = "BacklogBackground",
+
     EntryHighlightSprite = "EntryHighlight",
     EntryHighlightLocation = EntryHighlightLocationType.BottomLeftOfEntry,
     EntryHighlightOffset = { X = 0, Y = 0 },
+
     VoiceIconSprite = "VoiceIcon",
     VoiceIconOffset = { X = 0, Y = 0 },
+
     ScrollbarTrackSprite = "ScrollbarTrack",
     ScrollbarThumbSprite = "ScrollbarThumb",
     ScrollbarPosition = { X = 1165, Y = 98 },
     ScrollbarThumbLength = 0,
+
     EntriesStart = { X = 163, Y = 85 },
     RenderingBounds = { X = 87, Y = 83, Width = 1055, Height = 590 },
-    HoverBounds = { X = 87, Y = 83, Width = 1055, Height = 590 },
     EntryYPadding = 22,
+
+    HoverBounds = { X = 87, Y = 111, Width = 1072, Height = 602 },
+
     FadeInDuration = 0.2,
     FadeOutDuration = 0.2,
 

--- a/profiles/mo6tw/hud/backlogmenu.lua
+++ b/profiles/mo6tw/hud/backlogmenu.lua
@@ -14,13 +14,13 @@ root.BacklogMenu = {
     ScrollbarTrackSprite = "ScrollbarTrack",
     ScrollbarThumbSprite = "ScrollbarThumb",
     ScrollbarPosition = { X = 1165, Y = 98 },
-    ScrollbarThumbLength = 0,
+    ScrollbarThumbLength = 30,
 
-    EntriesStart = { X = 163, Y = 85 },
-    RenderingBounds = { X = 87, Y = 83, Width = 1055, Height = 590 },
+    EntriesStart = { X = 163, Y = 90 },
+    RenderingBounds = { X = 83, Y = 83, Width = 1117, Height = 590 },
     EntryYPadding = 22,
 
-    HoverBounds = { X = 87, Y = 111, Width = 1072, Height = 602 },
+    HoverBounds = { X = 130, Y = 83, Width = 992, Height = 590 },
 
     FadeInDuration = 0.2,
     FadeOutDuration = 0.2,
@@ -28,7 +28,7 @@ root.BacklogMenu = {
     ScrollingSpeed = 600,
     MinHoldTime = 0.5,
     AdvanceFocusTimeInterval = 0.05,
-    PageUpDownHeight = 550
+    PageUpDownHeight = 520
 };
 
 root.Sprites["BacklogBackground"] = {

--- a/src/games/cc/backlogmenu.cpp
+++ b/src/games/cc/backlogmenu.cpp
@@ -53,6 +53,17 @@ void BacklogMenu::Hide() {
   UI::BacklogMenu::Hide();
 }
 
+void BacklogMenu::Update(float dt) {
+  if (ScrWork[SW_SYSSUBMENUCT] < 32 && State == Shown) {
+    Hide();
+  } else if (ScrWork[SW_SYSSUBMENUCT] > 0 && State == Hidden &&
+             ScrWork[SW_SYSSUBMENUNO] == 1) {
+    Show();
+  }
+
+  UI::BacklogMenu::Update(dt);
+}
+
 void BacklogMenu::Render() {
   if (State == Hidden) return;
 

--- a/src/games/cc/backlogmenu.h
+++ b/src/games/cc/backlogmenu.h
@@ -12,7 +12,9 @@ class BacklogMenu : public UI::BacklogMenu {
  public:
   void Show() override;
   void Hide() override;
+  void Update(float dt) override;
   void Render() override;
+
   void MenuButtonOnClick(Widgets::BacklogEntry* target) override;
 
  private:

--- a/src/games/mo6tw/backlogmenu.cpp
+++ b/src/games/mo6tw/backlogmenu.cpp
@@ -19,6 +19,7 @@ void BacklogMenu::Render() {
   float opacity = glm::smoothstep(0.0f, 1.0f, FadeAnimation.Progress);
   glm::vec4 col(1.0f, 1.0f, 1.0f, opacity);
   MainItems->Tint = col;
+  MainScrollbar->Tint = col;
 
   Renderer->DrawSprite(BacklogBackground, glm::vec2(0.0f), col);
   RenderHighlight();

--- a/src/games/mo6tw/systemmenu.cpp
+++ b/src/games/mo6tw/systemmenu.cpp
@@ -78,7 +78,7 @@ void SystemMenu::Update(float dt) {
   UpdateInput();
 
   FadeAnimation.Update(dt);
-  if (GetFlag(SF_SYSTEMMENU) && State == Hidden) {
+  if (ScrWork[SW_SYSMENUALPHA] > 0 && State == Hidden) {
     Show();
   }
   if (ScrWork[SW_SYSMENUALPHA] < 256 && State == Shown) {

--- a/src/ui/backlogmenu.cpp
+++ b/src/ui/backlogmenu.cpp
@@ -2,6 +2,7 @@
 
 #include "ui.h"
 #include "../profile/game.h"
+#include "../profile/vm.h"
 #include "../renderer/renderer.h"
 #include "../mem.h"
 #include "../vm/interface/input.h"
@@ -224,21 +225,12 @@ void BacklogMenu::UpdateInput(float dt) {
 }
 
 void BacklogMenu::Update(float dt) {
-  if (ScrWork[SW_SYSSUBMENUCT] < 32 && State == Shown) {
-    Hide();
-  } else if (ScrWork[SW_SYSSUBMENUCT] > 0 && State == Hidden &&
-             ScrWork[SW_SYSSUBMENUNO] == 1) {
-    Show();
-  }
-
   if (State != Hidden && State != Shown) FadeAnimation.Update(dt);
 
-  if (State == Showing && FadeAnimation.IsIn() &&
-      ScrWork[SW_SYSSUBMENUCT] == 32) {
+  if (State == Showing && FadeAnimation.IsIn()) {
     State = Shown;
     IsFocused = true;
-  } else if (State == Hiding && FadeAnimation.IsOut() &&
-             ScrWork[SW_SYSSUBMENUCT] == 0) {
+  } else if (State == Hiding && FadeAnimation.IsOut()) {
     State = Hidden;
     IsFocused = false;
     if (UI::FocusedMenu) UI::FocusedMenu->IsFocused = true;
@@ -246,7 +238,7 @@ void BacklogMenu::Update(float dt) {
     MainItems->Hide();
   }
 
-  if (State == Shown && ScrWork[SW_SYSSUBMENUNO] == 1) {
+  if (State == Shown && IsFocused) {
     UpdateInput(dt);
 
     if (ItemsHeight > MainItems->RenderingBounds.Height) {

--- a/src/ui/backlogmenu.cpp
+++ b/src/ui/backlogmenu.cpp
@@ -331,11 +331,13 @@ void BacklogMenu::AddMessage(uint8_t* str, int audioId) {
 
     auto backlogEntry = CreateBacklogEntry(CurrentId, str, audioId,
                                            CurrentEntryPos, HoverBounds);
-    CurrentId += 1;
-    CurrentEntryPos.y += backlogEntry->TextHeight + EntryYPadding;
     backlogEntry->OnClickHandler = onClick;
     MainItems->Add(backlogEntry, FDIR_DOWN);
+    CurrentId++;
+
+    CurrentEntryPos.y += backlogEntry->TextHeight + EntryYPadding;
     ItemsHeight += backlogEntry->TextHeight + EntryYPadding;
+
     if (ItemsHeight > MainItems->RenderingBounds.Height) {
       MainScrollbar->EndValue = -ItemsHeight +
                                 MainItems->RenderingBounds.Height +

--- a/src/ui/widgets/backlogentry.cpp
+++ b/src/ui/widgets/backlogentry.cpp
@@ -40,11 +40,12 @@ BacklogEntry::BacklogEntry(int id, uint8_t* str, int audioId, glm::vec2 pos,
   for (const ProcessedTextGlyph& glyph : BacklogPage->Glyphs) {
     Bounds = RectF::Coalesce(Bounds, glyph.DestRect);
   }
-  Position = glm::vec2(Bounds.X, Bounds.Y);
+  Position.x = Bounds.X;  // X position should not take name into account
   for (const ProcessedTextGlyph& glyph : BacklogPage->Name) {
     Bounds = RectF::Coalesce(Bounds, glyph.DestRect);
   }
   TextHeight = Bounds.Height;
+  Position.y = Bounds.Y;  // Y position should
 
   switch (BacklogPage->Alignment) {
     default:

--- a/src/vm/inst_dialogue.cpp
+++ b/src/vm/inst_dialogue.cpp
@@ -608,8 +608,9 @@ VmInstruction(InstSetRevMes) {
 void ChkMesSkip() {
   bool mesSkip = false;
 
-  if (((ScrWork[SW_GAMESTATE] & 0b101) == 0b001) &&
-      (ScrWork[SW_SYSMESALPHA] == 255) && !GetFlag(SF_UIHIDDEN)) {
+  if (ScrWork[SW_SYSMESALPHA] != 255) MesSkipMode = false;
+
+  if ((ScrWork[SW_GAMESTATE] & 0b101) == 0b001 && !GetFlag(SF_UIHIDDEN)) {
     // Force skip
     mesSkip |=
         (bool)(Interface::PADinputButtonIsDown & Interface::PADcustom[7]);


### PR DESCRIPTION
Implements the following fixes for the regressions of MO6TW:
- Force skip works again (key E)
- Backlog name position no longer clips through bottom of previous line
- Backlog entries correctly show up when more than a page is filled
- Backlog menu takes focus when opened
- Improve profile settings to properly work with the overhauled backlog menu