### PR TITLE
Update and Fix text related to Ubuntu build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ impacto is currently being developed for **64-bit Windows 10 and desktop Linux P
 
 For building on Windows with Visual Studio 2019 or newer, please refer to the [building instructions](doc/vs_build.md).
 
-For building on Linux, see the [instructions for Ubuntu 18.04 Desktop](doc/ubuntu1804_build.md) and adapt to your distribution if necessary.
+For building on Linux, see the [instructions for Ubuntu 18.04 Desktop](doc/ubuntu_build.md) and adapt to your distribution if necessary.
 
 More platforms and toolchains are known to work.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ impacto is currently being developed for **64-bit Windows 10 and desktop Linux P
 
 For building on Windows with Visual Studio 2019 or newer, please refer to the [building instructions](doc/vs_build.md).
 
-For building on Linux, see the [instructions for Ubuntu 18.04 Desktop](doc/ubuntu_build.md) and adapt to your distribution if necessary.
+For building on Linux, see the [instructions for Ubuntu 20.04 Desktop](doc/ubuntu_build.md) and adapt to your distribution if necessary.
 
 More platforms and toolchains are known to work.
 


### PR DESCRIPTION
Currently in the README, the link to the ubuntu build instructions is broken since it links to a old filename instead of the current one, and on the README it lists the instructions for "18.04" instead of the current 20.04 shown in ubuntu_build.md

This pull request fixes both issues