### PR TITLE
Add new line in build docs to reduce confusion on running impacto

### DIFF
--- a/doc/ubuntu_build.md
+++ b/doc/ubuntu_build.md
@@ -29,3 +29,8 @@ cp -r src/shaders .
 LIBATRAC9DIR=vendor/LibAtrac9 cmake .
 make
 ```
+
+## Afterwards
+
+- Remember to follow the instructions in the [Getting Started guide](getting_started.md) to properly build and run impacto
+

--- a/doc/vs_build.md
+++ b/doc/vs_build.md
@@ -22,6 +22,11 @@ Run `.\build-deps.ps1` from a PowerShell prompt, addings args for architecture [
 - Open the project with *File->Open->Folder...* in Visual Studio
 - When picking a startup item, make sure to use `impacto.exe (Install)`
 
+
+## Afterwards
+
+- Remember to follow the instructions in the [Getting Started guide](getting_started.md) to properly build and run impacto
+
 ## Cry
 
 about the absolute state of C++ dependency management


### PR DESCRIPTION
Currently, a number of users (see: people on CoZ discord) are following the build instructions, then getting confused when their code doesn't run because they forgot to follow the instructions in getting started. this pull request adds a new line pointing the user to the getting started to reduce confusion.