### PR TITLE
Vm ip refactor

### DIFF
--- a/src/data/savesystem.h
+++ b/src/data/savesystem.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "../impacto.h"
+#include "../vm/vm.h"
 
 #include <string>
 #include <enum.h>

--- a/src/data/tipssystem.cpp
+++ b/src/data/tipssystem.cpp
@@ -10,9 +10,10 @@ using namespace Impacto::Profile::TipsSystem;
 
 void Init() { Configure(); }
 
-void DataInit(int scriptBufferId, uint8_t* tipsData, uint32_t tipsDataSize) {
+void DataInit(uint32_t scriptBufferId, uint32_t tipsDataAdr,
+              uint32_t tipsDataSize) {
   if (Implementation)
-    return Implementation->DataInit(scriptBufferId, tipsData, tipsDataSize);
+    return Implementation->DataInit(scriptBufferId, tipsDataAdr, tipsDataSize);
 
   ImpLog(LogLevel::Warning, LogChannel::VMStub,
          "{:s}: tips system not implemented, doing nothing\n", __func__);

--- a/src/data/tipssystem.h
+++ b/src/data/tipssystem.h
@@ -18,7 +18,7 @@ struct TipsDataRecord {
   uint16_t SortLetterIndex = 0;
   uint16_t ThumbnailIndex = 0;
   uint16_t NumberOfContentStrings = 0;
-  std::array<uint8_t*, MaxTipStrings> StringPtrs = {};
+  std::array<uint32_t, MaxTipStrings> StringAdr = {};
   bool IsLocked = true;
   bool IsUnread = true;
   bool IsNew = true;
@@ -28,7 +28,7 @@ class TipsSystemBase {
  public:
   TipsSystemBase(int maxTipsCount) : Records(maxTipsCount) {}
   virtual ~TipsSystemBase() {}
-  virtual void DataInit(int scriptBufferId, uint8_t* tipsData,
+  virtual void DataInit(uint32_t scriptBufferId, uint32_t tipsDataAdr,
                         uint32_t tipsDataSize) = 0;
   virtual void UpdateTipRecords() = 0;
   virtual void SetTipLockedState(int id, bool state) = 0;
@@ -45,7 +45,8 @@ class TipsSystemBase {
 inline TipsSystemBase* Implementation = nullptr;
 
 void Init();
-void DataInit(int scriptBufferId, uint8_t* tipsData, uint32_t tipsDataSize);
+void DataInit(uint32_t scriptBufferId, uint32_t tipsDataAdr,
+              uint32_t tipsDataSize);
 void UpdateTipRecords();
 void SetTipLockedState(int id, bool state);
 void SetTipUnreadState(int id, bool state);

--- a/src/games/cc/backlogmenu.h
+++ b/src/games/cc/backlogmenu.h
@@ -15,9 +15,9 @@ class BacklogMenu : public UI::BacklogMenu {
   void Render() override;
 
   Widgets::BacklogEntry* CreateBacklogEntry(
-      int id, uint8_t* str, int audioId, int characterId, glm::vec2 pos,
-      const RectF& hoverBounds) const override {
-    return new Widgets::CC::BacklogEntry(id, str, audioId, characterId, pos,
+      int id, Vm::BufferOffsetContext scrCtx, int audioId, int characterId,
+      glm::vec2 pos, const RectF& hoverBounds) const override {
+    return new Widgets::CC::BacklogEntry(id, scrCtx, audioId, characterId, pos,
                                          hoverBounds);
   }
 

--- a/src/games/cc/sysmesbox.cpp
+++ b/src/games/cc/sysmesbox.cpp
@@ -226,9 +226,11 @@ void SysMesBox::Init() {
   FadeAnimation.LoopMode = AnimationLoopMode::Stop;
 }
 
-void SysMesBox::AddMessage(uint8_t* str) {
+void SysMesBox::AddMessage(Vm::BufferOffsetContext ctx) {
   Impacto::Vm::Sc3VmThread dummy;
-  dummy.Ip = str;
+  dummy.IpOffset = ctx.IpOffset;
+  dummy.ScriptBufferId = ctx.ScriptBufferId;
+
   Messages[MessageCount] =
       TextLayoutPlainLine(&dummy, 255, Profile::Dialogue::DialogueFont,
                           TextFontSize, Profile::Dialogue::ColorTable[0], 1.0f,
@@ -243,9 +245,10 @@ void SysMesBox::AddMessage(uint8_t* str) {
   }
 }
 
-void SysMesBox::AddChoice(uint8_t* str) {
+void SysMesBox::AddChoice(Vm::BufferOffsetContext ctx) {
   Impacto::Vm::Sc3VmThread dummy;
-  dummy.Ip = str;
+  dummy.IpOffset = ctx.IpOffset;
+  dummy.ScriptBufferId = ctx.ScriptBufferId;
   Choices[ChoiceCount] =
       TextLayoutPlainLine(&dummy, 255, Profile::Dialogue::DialogueFont,
                           TextFontSize, Profile::Dialogue::ColorTable[0], 1.0f,

--- a/src/games/cc/sysmesbox.h
+++ b/src/games/cc/sysmesbox.h
@@ -15,8 +15,8 @@ class SysMesBox : public UI::SysMesBox {
   virtual void Render() override;
 
   virtual void Init() override;
-  virtual void AddMessage(uint8_t* str) override;
-  virtual void AddChoice(uint8_t* str) override;
+  virtual void AddMessage(Vm::BufferOffsetContext ctx) override;
+  virtual void AddChoice(Vm::BufferOffsetContext ctx) override;
 
  private:
   void ChoiceItemOnClick(UI::Widgets::Button* target);

--- a/src/games/cclcc/musicmenu.cpp
+++ b/src/games/cclcc/musicmenu.cpp
@@ -24,10 +24,10 @@ MusicTrackButton::MusicTrackButton(int id, int position, glm::vec2 pos)
                  MusicButtonBounds.Height);
   IsLocked = !SaveSystem::GetBgmFlag(MusicBGMFlagIds[Id]);
   uint32_t trackTextIndex = 2 * Id;
-  SetText(
-      Vm::ScriptGetTextTableStrAddress(MusicStringTableId, trackTextIndex + 6),
-      MusicTrackNameSize, RendererOutlineMode::None,
-      {MusicButtonTextColor, MusicButtonTextOutlineColor});
+  auto const trackText =
+      Vm::ScriptGetTextTableStrAddress(MusicStringTableId, trackTextIndex + 6);
+  SetText(trackText, MusicTrackNameSize, RendererOutlineMode::None,
+          {MusicButtonTextColor, MusicButtonTextOutlineColor});
   Bounds =
       RectF(pos.x, pos.y, MusicButtonBounds.Width, MusicButtonBounds.Height);
   HighlightSprite = MusicButtonHoverSprite;
@@ -36,10 +36,10 @@ MusicTrackButton::MusicTrackButton(int id, int position, glm::vec2 pos)
   for (int i = 0; i < Text.size(); i++) {
     Text[i].DestRect.X += MusicTrackNameOffsetX;
   }
-  auto* const lockedSc3Text = Vm::ScriptGetTextTableStrAddress(
+  auto const lockedSc3Text = Vm::ScriptGetTextTableStrAddress(
       MusicStringTableId, MusicStringLockedIndex);
   Vm::Sc3VmThread dummy;
-  dummy.Ip = lockedSc3Text;
+  dummy.SetIp(lockedSc3Text);
   TextLayoutPlainLine(&dummy, 6, LockedText, Profile::Dialogue::DialogueFont,
                       MusicTrackNameSize,
                       {MusicButtonTextColor, MusicButtonTextOutlineColor}, 1.0f,

--- a/src/games/cclcc/savesystem.cpp
+++ b/src/games/cclcc/savesystem.cpp
@@ -773,9 +773,9 @@ void SaveSystem::LoadMemoryNew(LoadProcess load) {
       thd->ScriptParam = WorkingSaveEntry->MainThreadScriptParam;
       thd->GroupId = WorkingSaveEntry->MainThreadGroupId;
       thd->ScriptBufferId = WorkingSaveEntry->MainThreadScriptBufferId;
-      thd->Ip = ScriptGetRetAddress(
-          ScriptBuffers[WorkingSaveEntry->MainThreadScriptBufferId],
-          WorkingSaveEntry->MainThreadIp);
+      thd->IpOffset =
+          ScriptGetRetAddress(WorkingSaveEntry->MainThreadScriptBufferId,
+                              WorkingSaveEntry->MainThreadIp);
       thd->CallStackDepth = WorkingSaveEntry->MainThreadCallStackDepth;
 
       for (size_t i = 0; i < thd->CallStackDepth; i++) {

--- a/src/games/cclcc/savesystem.cpp
+++ b/src/games/cclcc/savesystem.cpp
@@ -269,7 +269,7 @@ SaveError SaveSystem::MountSaveFile(std::vector<QueuedTexture>& textures) {
   for (auto& entryArray : {FullSaveEntries, QuickSaveEntries}) {
     SaveType saveType =
         (entryArray == QuickSaveEntries) ? SaveType::Quick : SaveType::Full;
-    int64_t saveDataPos = stream->Position;
+    [[maybe_unused]] int64_t saveDataPos = stream->Position;
     for (int i = 0; i < MaxSaveEntries; i++) {
       assert(stream->Position - saveDataPos == 0x1b110 * i);
       entryArray[i] = new SaveFileEntry();
@@ -600,7 +600,7 @@ SaveError SaveSystem::WriteSaveFile() {
   for (auto* entryArray : {FullSaveEntries, QuickSaveEntries}) {
     SaveType saveType =
         (entryArray == QuickSaveEntries) ? SaveType::Quick : SaveType::Full;
-    int64_t saveDataPos = stream->Position;
+    [[maybe_unused]] int64_t saveDataPos = stream->Position;
     for (int i = 0; i < MaxSaveEntries; i++) {
       SaveFileEntry* entry = (SaveFileEntry*)entryArray[i];
       if (entry->Status == 0) {

--- a/src/games/cclcc/tipsnotification.cpp
+++ b/src/games/cclcc/tipsnotification.cpp
@@ -52,9 +52,10 @@ void TipsNotification::Update(float dt) {
   PositionY = (float)(static_cast<int>(FadeAnimation.Progress * 255 * 96) >> 8);
 
   auto UpdateNotificationDisplay = [&]() {
-    auto tipName = NotificationQueue.front();
-    TipName.SetText(tipName, FontSize, RendererOutlineMode::BottomRight,
-                    TipNameColor);
+    auto tipNameAdr = NotificationQueue.front();
+    auto tipsScrBufId = TipsSystem::GetTipsScriptBufferId();
+    TipName.SetText({.ScriptBufferId = tipsScrBufId, .IpOffset = tipNameAdr},
+                    FontSize, RendererOutlineMode::BottomRight, TipNameColor);
     Timer.DurationIn = TimerDuration + TipName.GetTextLength() * 0.1f;
     NotificationQueue.pop();
   };
@@ -100,7 +101,7 @@ void TipsNotification::Render() {
 
 void TipsNotification::AddTip(int tipId) {
   auto record = TipsSystem::GetTipRecord(tipId);
-  NotificationQueue.push(record->StringPtrs[1]);
+  NotificationQueue.push(record->StringAdr[1]);
 }
 
 }  // namespace CCLCC

--- a/src/games/cclcc/tipssystem.cpp
+++ b/src/games/cclcc/tipssystem.cpp
@@ -13,7 +13,7 @@ using namespace Impacto::Vm;
 using namespace Impacto::Profile::TipsSystem;
 using namespace Impacto::Io;
 
-void TipsSystem::DataInit(int scriptBufferId, uint8_t *tipsData,
+void TipsSystem::DataInit(uint32_t scriptBufferId, uint32_t tipsDataAdr,
                           uint32_t tipsDataSize) {
   ScriptBufferId = (uint8_t)scriptBufferId;
   auto scriptBuffer = ScriptBuffers[scriptBufferId];
@@ -21,7 +21,8 @@ void TipsSystem::DataInit(int scriptBufferId, uint8_t *tipsData,
   TipEntryCount = 0;
 
   // Read tips data from the script and create UI elements for each tip
-  MemoryStream stream = MemoryStream(tipsData, tipsDataSize, false);
+  MemoryStream stream =
+      MemoryStream(&scriptBuffer[tipsDataAdr], tipsDataSize, false);
   int numberOfContentStrings = ReadLE<uint16_t>(&stream);
   while (numberOfContentStrings != 255) {
     if (TipEntryCount >= MaxTipsCount) {
@@ -34,8 +35,8 @@ void TipsSystem::DataInit(int scriptBufferId, uint8_t *tipsData,
     // TODO: record.SortLetterIndex
     record.NumberOfContentStrings = (uint16_t)numberOfContentStrings;
     for (int i = 0; i < numberOfContentStrings + 4; i++) {
-      record.StringPtrs[i] =
-          ScriptGetStrAddress(scriptBuffer, ReadLE<uint16_t>(&stream));
+      record.StringAdr[i] =
+          ScriptGetStrAddress(scriptBufferId, ReadLE<uint16_t>(&stream));
     }
     Records[TipEntryCount] = std::move(record);
 

--- a/src/games/cclcc/tipssystem.h
+++ b/src/games/cclcc/tipssystem.h
@@ -11,7 +11,7 @@ class TipsSystem : public TipsSystemBase {
  public:
   TipsSystem(int maxTipsCount) : TipsSystemBase(maxTipsCount) {};
 
-  void DataInit(int scriptBufferId, uint8_t* tipsData,
+  void DataInit(uint32_t scriptBufferId, uint32_t tipsData,
                 uint32_t tipsDataSize) override;
   void UpdateTipRecords() override;
   void SetTipLockedState(int id, bool state) override;

--- a/src/games/chlcc/savesystem.cpp
+++ b/src/games/chlcc/savesystem.cpp
@@ -460,16 +460,11 @@ void SaveSystem::LoadEntry(SaveType type, int id) {
         thd->ScriptParam = entry->MainThreadScriptParam;
         thd->GroupId = entry->MainThreadGroupId >> 16;
         thd->ScriptBufferId = entry->MainThreadGroupId & 0xFFFF;
-        LoadScript(thd->ScriptBufferId, ScrWork[2004 + thd->ScriptBufferId]);
-        ScrWork[2004 + thd->ScriptBufferId] = 65535;
         thd->IpOffset = entry->MainThreadIp;
         thd->CallStackDepth = entry->MainThreadCallStackDepth;
 
         for (size_t i = 0; i < thd->CallStackDepth; i++) {
           thd->ReturnScriptBufferIds[i] = entry->MainThreadReturnBufIds[i];
-          LoadScript(entry->MainThreadReturnBufIds[i],
-                     ScrWork[2004 + entry->MainThreadReturnBufIds[i]]);
-          ScrWork[2004 + entry->MainThreadReturnBufIds[i]] = 65535;
           thd->ReturnAddresses[i] = entry->MainThreadReturnAddresses[i];
         }
 

--- a/src/games/chlcc/savesystem.cpp
+++ b/src/games/chlcc/savesystem.cpp
@@ -221,7 +221,7 @@ SaveError SaveSystem::WriteSaveFile() {
   Io::WriteArrayLE<uint8_t>(SystemData.data(), stream, SystemData.size());
 
   for (auto& entryArray : {QuickSaveEntries, FullSaveEntries}) {
-    int64_t saveDataPos = stream->Position;
+    [[maybe_unused]] int64_t saveDataPos = stream->Position;
     for (int i = 0; i < MaxSaveEntries; i++) {
       assert(stream->Position - saveDataPos == i * 0x2000);
       SaveFileEntry* entry = (SaveFileEntry*)entryArray[i];

--- a/src/games/chlcc/sysmesbox.cpp
+++ b/src/games/chlcc/sysmesbox.cpp
@@ -189,9 +189,10 @@ void SysMesBox::Init() {
   FadeAnimation.LoopMode = AnimationLoopMode::Stop;
 }
 
-void SysMesBox::AddMessage(uint8_t* str) {
+void SysMesBox::AddMessage(Vm::BufferOffsetContext ctx) {
   Impacto::Vm::Sc3VmThread dummy;
-  dummy.Ip = str;
+  dummy.IpOffset = ctx.IpOffset;
+  dummy.ScriptBufferId = ctx.ScriptBufferId;
   Messages[MessageCount] =
       TextLayoutPlainLine(&dummy, 255, Profile::Dialogue::DialogueFont,
                           TextFontSize, Profile::Dialogue::ColorTable[10], 1.0f,
@@ -204,9 +205,10 @@ void SysMesBox::AddMessage(uint8_t* str) {
   MessageCount++;
 }
 
-void SysMesBox::AddChoice(uint8_t* str) {
+void SysMesBox::AddChoice(Vm::BufferOffsetContext ctx) {
   Impacto::Vm::Sc3VmThread dummy;
-  dummy.Ip = str;
+  dummy.IpOffset = ctx.IpOffset;
+  dummy.ScriptBufferId = ctx.ScriptBufferId;
   Choices[ChoiceCount] =
       TextLayoutPlainLine(&dummy, 255, Profile::Dialogue::DialogueFont,
                           TextFontSize, Profile::Dialogue::ColorTable[10], 1.0f,

--- a/src/games/chlcc/sysmesbox.h
+++ b/src/games/chlcc/sysmesbox.h
@@ -22,8 +22,8 @@ class SysMesBox : public UI::SysMesBox {
   virtual void Render() override;
 
   virtual void Init() override;
-  virtual void AddMessage(uint8_t* str) override;
-  virtual void AddChoice(uint8_t* str) override;
+  virtual void AddMessage(Vm::BufferOffsetContext ctx) override;
+  virtual void AddChoice(Vm::BufferOffsetContext ctx) override;
 
  private:
   std::array<SysMesBoxStar, 14> LoadingStars;

--- a/src/games/chlcc/tipssystem.cpp
+++ b/src/games/chlcc/tipssystem.cpp
@@ -13,14 +13,15 @@ using namespace Impacto::Vm;
 using namespace Impacto::Profile::TipsSystem;
 using namespace Impacto::Io;
 
-void TipsSystem::DataInit(int scriptBufferId, uint8_t *tipsData,
+void TipsSystem::DataInit(uint32_t scriptBufferId, uint32_t tipsDataAdr,
                           uint32_t tipsDataSize) {
   ScriptBufferId = (uint8_t)scriptBufferId;
   auto scriptBuffer = ScriptBuffers[scriptBufferId];
 
   int idx = 0;
   // Read tips data from the script and create UI elements for each tip
-  MemoryStream *stream = new MemoryStream(tipsData, tipsDataSize);
+  MemoryStream *stream =
+      new MemoryStream(&scriptBuffer[tipsDataAdr], tipsDataSize);
   auto numberOfContentStrings = ReadLE<uint16_t>(stream);
   while (numberOfContentStrings != 255) {
     // Read tip entry from the data array
@@ -30,8 +31,8 @@ void TipsSystem::DataInit(int scriptBufferId, uint8_t *tipsData,
     // TODO: record.SortLetterIndex
     record.NumberOfContentStrings = numberOfContentStrings;
     for (int i = 0; i < record.NumberOfContentStrings + 4; i++) {
-      record.StringPtrs[i] =
-          ScriptGetStrAddress(scriptBuffer, ReadLE<uint16_t>(stream));
+      record.StringAdr[i] =
+          ScriptGetStrAddress(scriptBufferId, ReadLE<uint16_t>(stream));
     }
     Records[idx] = record;
 

--- a/src/games/chlcc/tipssystem.h
+++ b/src/games/chlcc/tipssystem.h
@@ -11,7 +11,8 @@ class TipsSystem : public TipsSystemBase {
  public:
   TipsSystem(int maxTipsCount) : TipsSystemBase(maxTipsCount) {};
 
-  void DataInit(int scriptBufferId, uint8_t* tipsData, uint32_t tipsDataSize);
+  void DataInit(uint32_t scriptBufferId, uint32_t tipsDataAdr,
+                uint32_t tipsDataSize);
   void UpdateTipRecords();
   void SetTipLockedState(int id, bool state);
   void SetTipUnreadState(int id, bool state);

--- a/src/games/darling/sysmesbox.cpp
+++ b/src/games/darling/sysmesbox.cpp
@@ -165,9 +165,10 @@ void SysMesBox::Init() {
   FadeAnimation.LoopMode = AnimationLoopMode::Stop;
 }
 
-void SysMesBox::AddMessage(uint8_t* str) {
+void SysMesBox::AddMessage(Vm::BufferOffsetContext ctx) {
   Impacto::Vm::Sc3VmThread dummy;
-  dummy.Ip = str;
+  dummy.IpOffset = ctx.IpOffset;
+  dummy.ScriptBufferId = ctx.ScriptBufferId;
   Messages[MessageCount] =
       TextLayoutPlainLine(&dummy, 255, Profile::Dialogue::DialogueFont,
                           TextFontSize, Profile::Dialogue::ColorTable[10], 1.0f,
@@ -180,9 +181,10 @@ void SysMesBox::AddMessage(uint8_t* str) {
   MessageCount++;
 }
 
-void SysMesBox::AddChoice(uint8_t* str) {
+void SysMesBox::AddChoice(Vm::BufferOffsetContext ctx) {
   Impacto::Vm::Sc3VmThread dummy;
-  dummy.Ip = str;
+  dummy.IpOffset = ctx.IpOffset;
+  dummy.ScriptBufferId = ctx.ScriptBufferId;
   Choices[ChoiceCount] =
       TextLayoutPlainLine(&dummy, 255, Profile::Dialogue::DialogueFont,
                           TextFontSize, Profile::Dialogue::ColorTable[10], 1.0f,

--- a/src/games/darling/sysmesbox.h
+++ b/src/games/darling/sysmesbox.h
@@ -15,8 +15,8 @@ class SysMesBox : public UI::SysMesBox {
   virtual void Render() override;
 
   virtual void Init() override;
-  virtual void AddMessage(uint8_t* str) override;
-  virtual void AddChoice(uint8_t* str) override;
+  virtual void AddMessage(Vm::BufferOffsetContext ctx) override;
+  virtual void AddChoice(Vm::BufferOffsetContext ctx) override;
 
  private:
   void ChoiceItemOnClick(UI::Widgets::Button* target);

--- a/src/games/mo6tw/clearlistmenu.cpp
+++ b/src/games/mo6tw/clearlistmenu.cpp
@@ -193,20 +193,22 @@ void ClearListMenu::InitMainPage() {
 
   Vm::Sc3VmThread dummy;
   uint16_t sc3StringBuffer[10];
+  Vm::Sc3Stream sc3StrStream(sc3StringBuffer);
 
   auto separator =
       Vm::ScriptGetTextTableStrAddress(SeparatorTable, SeparatorEntry);
-  dummy.Ip = separator;
+  dummy.IpOffset = separator.IpOffset;
+  dummy.ScriptBufferId = separator.ScriptBufferId;
   SeparatorWidth =
       TextGetPlainLineWidth(&dummy, Profile::Dialogue::DialogueFont, FontSize);
 
   // Ending count
   TextGetSc3String(fmt::to_string(EndingCount), sc3StringBuffer);
-  dummy.Ip = (uint8_t*)sc3StringBuffer;
-  EndingCountWidth =
-      TextGetPlainLineWidth(&dummy, Profile::Dialogue::DialogueFont, FontSize);
+  EndingCountWidth = TextGetPlainLineWidth(
+      sc3StrStream, Profile::Dialogue::DialogueFont, FontSize);
+  sc3StrStream = Vm::Sc3Stream(sc3StringBuffer);
   MainPage->Add(new Label(
-      (uint8_t*)sc3StringBuffer,
+      sc3StrStream,
       glm::vec2(
           (EndingsLabelPosition.x - EndingCountWidth) + EndingCountPosition.x,
           EndingCountPosition.y),
@@ -224,10 +226,10 @@ void ClearListMenu::InitMainPage() {
 
   // Scene count
   TextGetSc3String(fmt::to_string(SceneCount), sc3StringBuffer);
-  dummy.Ip = (uint8_t*)sc3StringBuffer;
-  SceneCountWidth =
-      TextGetPlainLineWidth(&dummy, Profile::Dialogue::DialogueFont, FontSize);
-  MainPage->Add(new Label((uint8_t*)sc3StringBuffer,
+  SceneCountWidth = TextGetPlainLineWidth(
+      sc3StrStream, Profile::Dialogue::DialogueFont, FontSize);
+  sc3StrStream = Vm::Sc3Stream(sc3StringBuffer);
+  MainPage->Add(new Label(sc3StrStream,
                           glm::vec2((ScenesLabelPosition.x - SceneCountWidth) +
                                         SceneCountPosition.x,
                                     SceneCountPosition.y),
@@ -251,11 +253,12 @@ void ClearListMenu::InitMainPage() {
   int totalCount = 0, unlockedCount = 0;
   SaveSystem::GetViewedEVsCount(&totalCount, &unlockedCount);
   TextGetSc3String(fmt::to_string(totalCount), sc3StringBuffer);
-  dummy.Ip = (uint8_t*)sc3StringBuffer;
-  AlbumCountWidth =
-      TextGetPlainLineWidth(&dummy, Profile::Dialogue::DialogueFont, FontSize);
+  sc3StrStream = Vm::Sc3Stream(sc3StringBuffer);
+  AlbumCountWidth = TextGetPlainLineWidth(
+      sc3StrStream, Profile::Dialogue::DialogueFont, FontSize);
+  sc3StrStream = Vm::Sc3Stream(sc3StringBuffer);
   MainPage->Add(new Label(
-      (uint8_t*)sc3StringBuffer,
+      sc3StrStream,
       glm::vec2((AlbumLabelPosition.x - AlbumCountWidth) + AlbumCountPosition.x,
                 AlbumCountPosition.y),
       FontSize, RendererOutlineMode::None, ClearListColorIndex));
@@ -273,7 +276,7 @@ void ClearListMenu::InitMainPage() {
   // Play time
   auto secondsText = Vm::ScriptGetTextTableStrAddress(PlayTimeTextTable,
                                                       PlayTimeSecondsTextEntry);
-  dummy.Ip = secondsText;
+  dummy.SetIp(secondsText);
   SecondsTextWidth =
       TextGetPlainLineWidth(&dummy, Profile::Dialogue::DialogueFont, FontSize);
   MainPage->Add(new Label(secondsText,
@@ -285,7 +288,7 @@ void ClearListMenu::InitMainPage() {
 
   auto minutesText = Vm::ScriptGetTextTableStrAddress(PlayTimeTextTable,
                                                       PlayTimeMinutesTextEntry);
-  dummy.Ip = minutesText;
+  dummy.SetIp(minutesText);
   MinutesTextWidth =
       TextGetPlainLineWidth(&dummy, Profile::Dialogue::DialogueFont, FontSize);
   MainPage->Add(
@@ -297,7 +300,7 @@ void ClearListMenu::InitMainPage() {
 
   auto hoursText = Vm::ScriptGetTextTableStrAddress(PlayTimeTextTable,
                                                     PlayTimeHoursTextEntry);
-  dummy.Ip = hoursText;
+  dummy.SetIp(hoursText);
   HoursTextWidth =
       TextGetPlainLineWidth(&dummy, Profile::Dialogue::DialogueFont, FontSize);
   HoursText = new Label(
@@ -324,127 +327,129 @@ void ClearListMenu::InitMainPage() {
 }
 
 void ClearListMenu::UpdateEndingCount() {
-  Vm::Sc3VmThread dummy;
   uint16_t sc3StringBuffer[10];
+  Vm::Sc3Stream stream(sc3StringBuffer);
 
   int unlockedEndingCount = 0;
   for (int i = 0; i < EndingCount; i++) {
     unlockedEndingCount += GetFlag(SF_CLR_END1 + i);
   }
   TextGetSc3String(fmt::format("{:2}", unlockedEndingCount), sc3StringBuffer);
-  dummy.Ip = (uint8_t*)sc3StringBuffer;
   float unlockedEndingCountWidth =
-      TextGetPlainLineWidth(&dummy, Profile::Dialogue::DialogueFont, FontSize);
+      TextGetPlainLineWidth(stream, Profile::Dialogue::DialogueFont, FontSize);
+  stream = Vm::Sc3Stream(sc3StringBuffer);
   UnlockedEndingCount->Bounds.X =
       (EndingsLabelPosition.x -
        (EndingCountWidth + SeparatorWidth + unlockedEndingCountWidth)) +
       EndingCountPosition.x;
   UnlockedEndingCount->Bounds.Y = EndingCountPosition.y;
-  UnlockedEndingCount->SetText((uint8_t*)sc3StringBuffer, FontSize,
-                               RendererOutlineMode::None, ClearListColorIndex);
+  UnlockedEndingCount->SetText(stream, FontSize, RendererOutlineMode::None,
+                               ClearListColorIndex);
 }
 
 void ClearListMenu::UpdateSceneCount() {
-  Vm::Sc3VmThread dummy;
   uint16_t sc3StringBuffer[10];
-
+  Vm::Sc3Stream stream(sc3StringBuffer);
   int unlockedSceneCount = 0;
   for (int i = 0; i < SceneCount; ++i) {
     unlockedSceneCount += GetFlag(SF_SCN_CLR1 + i);
   }
   TextGetSc3String(fmt::to_string(unlockedSceneCount), sc3StringBuffer);
-  dummy.Ip = (uint8_t*)sc3StringBuffer;
   float unlockedSceneCountWidth =
-      TextGetPlainLineWidth(&dummy, Profile::Dialogue::DialogueFont, FontSize);
+      TextGetPlainLineWidth(stream, Profile::Dialogue::DialogueFont, FontSize);
+  stream = Vm::Sc3Stream(sc3StringBuffer);
   UnlockedSceneCount->Bounds.X =
       (ScenesLabelPosition.x -
        (SceneCountWidth + SeparatorWidth + unlockedSceneCountWidth)) +
       SceneCountPosition.x;
   UnlockedSceneCount->Bounds.Y = SceneCountPosition.y;
-  UnlockedSceneCount->SetText((uint8_t*)sc3StringBuffer, FontSize,
-                              RendererOutlineMode::None, ClearListColorIndex);
+  UnlockedSceneCount->SetText(stream, FontSize, RendererOutlineMode::None,
+                              ClearListColorIndex);
 }
 
 void ClearListMenu::UpdateAlbumCount() {
-  Vm::Sc3VmThread dummy;
   uint16_t sc3StringBuffer[10];
+  Vm::Sc3Stream stream(sc3StringBuffer);
 
   int totalCount = 0, unlockedCount = 0;
   SaveSystem::GetViewedEVsCount(&totalCount, &unlockedCount);
   TextGetSc3String(fmt::to_string(unlockedCount), sc3StringBuffer);
-  dummy.Ip = (uint8_t*)sc3StringBuffer;
   float unlockedAlbumCountWidth =
-      TextGetPlainLineWidth(&dummy, Profile::Dialogue::DialogueFont, FontSize);
+      TextGetPlainLineWidth(stream, Profile::Dialogue::DialogueFont, FontSize);
+  stream = Vm::Sc3Stream(sc3StringBuffer);
   UnlockedAlbumCount->Bounds.X =
       (AlbumLabelPosition.x -
        (AlbumCountWidth + SeparatorWidth + unlockedAlbumCountWidth)) +
       AlbumCountPosition.x;
   UnlockedAlbumCount->Bounds.Y = AlbumCountPosition.y;
-  UnlockedAlbumCount->SetText((uint8_t*)sc3StringBuffer, FontSize,
-                              RendererOutlineMode::None, ClearListColorIndex);
+  UnlockedAlbumCount->SetText(stream, FontSize, RendererOutlineMode::None,
+                              ClearListColorIndex);
 }
 
 void ClearListMenu::UpdateCompletionPercentage() {
-  Vm::Sc3VmThread dummy;
   uint16_t sc3StringBuffer[10];
+  Vm::Sc3Stream stream(sc3StringBuffer);
+
   int totalMessageCount = 0, readMessageCount = 0;
 
   SaveSystem::GetReadMessagesCount(&totalMessageCount, &readMessageCount);
   float readPercentage = readMessageCount / (float)totalMessageCount * 100.0f;
   TextGetSc3String(fmt::format("{:.2f}%", readPercentage), sc3StringBuffer);
-  dummy.Ip = (uint8_t*)sc3StringBuffer;
   float percentageWidth =
-      TextGetPlainLineWidth(&dummy, Profile::Dialogue::DialogueFont, FontSize);
+      TextGetPlainLineWidth(stream, Profile::Dialogue::DialogueFont, FontSize);
+  stream = Vm::Sc3Stream(sc3StringBuffer);
+
   CompletionPercentage->Bounds.X =
       CompletionLabelPosition.x - percentageWidth + CompletionPosition.x;
   CompletionPercentage->Bounds.Y = CompletionPosition.y;
-  CompletionPercentage->SetText((uint8_t*)sc3StringBuffer, FontSize,
-                                RendererOutlineMode::None, ClearListColorIndex);
+  CompletionPercentage->SetText(stream, FontSize, RendererOutlineMode::None,
+                                ClearListColorIndex);
 }
 
 void ClearListMenu::UpdatePlayTime() {
-  Vm::Sc3VmThread dummy;
   auto seconds = ScrWork[SW_TOTALPLAYTIME] % 3600 % 60;
   auto minutes = ScrWork[SW_TOTALPLAYTIME] % 3600 / 60;
   auto hours = ScrWork[SW_TOTALPLAYTIME] / 3600;
 
   uint16_t sc3StringBuffer[10];
+  Vm::Sc3Stream stream(sc3StringBuffer);
 
   TextGetSc3String(fmt::format("{:2d}", seconds), sc3StringBuffer);
-  dummy.Ip = (uint8_t*)sc3StringBuffer;
   float secondsWidth =
-      TextGetPlainLineWidth(&dummy, Profile::Dialogue::DialogueFont, FontSize);
+      TextGetPlainLineWidth(stream, Profile::Dialogue::DialogueFont, FontSize);
+  stream = Vm::Sc3Stream(sc3StringBuffer);
   PlaySeconds->Bounds.X = PlayTimeLabelPosition.x -
                           (SecondsTextWidth + secondsWidth) +
                           PlayTimeSecondsPosition.x;
   PlaySeconds->Bounds.Y = PlayTimeSecondsPosition.y;
-  PlaySeconds->SetText((uint8_t*)sc3StringBuffer, FontSize,
-                       RendererOutlineMode::None, ClearListColorIndex);
-
+  PlaySeconds->SetText(stream, FontSize, RendererOutlineMode::None,
+                       ClearListColorIndex);
   TextGetSc3String(fmt::format("{:2d}", minutes), sc3StringBuffer);
-  dummy.Ip = (uint8_t*)sc3StringBuffer;
+  stream = Vm::Sc3Stream(sc3StringBuffer);
   float minutesWidth =
-      TextGetPlainLineWidth(&dummy, Profile::Dialogue::DialogueFont, FontSize);
+      TextGetPlainLineWidth(stream, Profile::Dialogue::DialogueFont, FontSize);
+  stream = Vm::Sc3Stream(sc3StringBuffer);
   PlayMinutes->Bounds.X = PlayTimeLabelPosition.x -
                           (SecondsTextWidth + MinutesTextWidth + minutesWidth) +
                           PlayTimeMinutesPosition.x;
   PlayMinutes->Bounds.Y = PlayTimeMinutesPosition.y;
-  PlayMinutes->SetText((uint8_t*)sc3StringBuffer, FontSize,
-                       RendererOutlineMode::None, ClearListColorIndex);
+  PlayMinutes->SetText(stream, FontSize, RendererOutlineMode::None,
+                       ClearListColorIndex);
 
   if (hours != 0) {
     HoursText->Tint.a = FadeAnimation.Progress;
     PlayHours->Tint.a = FadeAnimation.Progress;
     TextGetSc3String(fmt::format("{:2d}", hours), sc3StringBuffer);
-    dummy.Ip = (uint8_t*)sc3StringBuffer;
+    stream = Vm::Sc3Stream(sc3StringBuffer);
     float hoursWidth = TextGetPlainLineWidth(
-        &dummy, Profile::Dialogue::DialogueFont, FontSize);
+        stream, Profile::Dialogue::DialogueFont, FontSize);
+    stream = Vm::Sc3Stream(sc3StringBuffer);
     PlayHours->Bounds.X = PlayTimeLabelPosition.x - SecondsTextWidth -
                           MinutesTextWidth - (HoursTextWidth + hoursWidth) +
                           PlayTimeHoursPosition.x;
     PlayHours->Bounds.Y = PlayTimeHoursPosition.y;
-    PlayHours->SetText((uint8_t*)sc3StringBuffer, FontSize,
-                       RendererOutlineMode::None, ClearListColorIndex);
+    PlayHours->SetText(stream, FontSize, RendererOutlineMode::None,
+                       ClearListColorIndex);
   } else {
     PlayHours->Tint.a = 0.0f;
     HoursText->Tint.a = 0.0f;

--- a/src/games/mo6tw/savesystem.cpp
+++ b/src/games/mo6tw/savesystem.cpp
@@ -546,26 +546,15 @@ void SaveSystem::LoadEntry(SaveType type, int id) {
         thd->ScriptParam = entry->MainThreadScriptParam;
         thd->GroupId = entry->MainThreadGroupId >> 16;
         thd->ScriptBufferId = entry->MainThreadGroupId & 0xFFFF;
-        LoadScript(thd->ScriptBufferId, ScrWork[2004 + thd->ScriptBufferId]);
         thd->IpOffset = entry->MainThreadIp;
         // thd->CallStackDepth = entry->MainThreadCallStackDepth;
 
-        LoadScript(entry->MainThreadReturnBufIds[0],
-                   ScrWork[2004 + entry->MainThreadReturnBufIds[0]]);
         thd->CallStackDepth++;
         thd->ReturnScriptBufferIds[0] = entry->MainThreadReturnBufIds[0];
         thd->ReturnAddresses[0] = entry->MainThreadReturnIds[0];
 
         memcpy(thd->Variables, entry->MainThreadVariables, 64);
         thd->DialoguePageId = entry->MainThreadDialoguePageId;
-
-        // Tell the script side of save loading that we already loaded the
-        // needed scripts ourselves
-        // TODO: Figure out a better way of loading in general
-        ScrWork[SW_SVSCRNO1] = 65535;
-        ScrWork[SW_SVSCRNO2] = 65535;
-        ScrWork[SW_SVSCRNO3] = 65535;
-        ScrWork[SW_SVSCRNO4] = 65535;
       }
     }
 }

--- a/src/games/mo6tw/savesystem.cpp
+++ b/src/games/mo6tw/savesystem.cpp
@@ -433,14 +433,11 @@ void SaveSystem::SaveMemory() {
       WorkingSaveEntry->MainThreadScriptParam = thd->ScriptParam;
       WorkingSaveEntry->MainThreadGroupId = thd->GroupId << 16;
       WorkingSaveEntry->MainThreadGroupId |= thd->ScriptBufferId;
-      WorkingSaveEntry->MainThreadIp =
-          (uint32_t)(thd->Ip - ScriptBuffers[thd->ScriptBufferId]);
+      WorkingSaveEntry->MainThreadIp = thd->IpOffset;
       WorkingSaveEntry->MainThreadCallStackDepth = thd->CallStackDepth;
 
       for (size_t j = 0; j < thd->CallStackDepth; j++) {
-        WorkingSaveEntry->MainThreadReturnIds[j] =
-            (uint32_t)(thd->ReturnAddresses[j] -
-                       ScriptBuffers[thd->ReturnScriptBufferIds[j]]);
+        WorkingSaveEntry->MainThreadReturnIds[j] = thd->ReturnAddresses[j];
         WorkingSaveEntry->MainThreadReturnBufIds[j] =
             thd->ReturnScriptBufferIds[j];
       }
@@ -550,16 +547,14 @@ void SaveSystem::LoadEntry(SaveType type, int id) {
         thd->GroupId = entry->MainThreadGroupId >> 16;
         thd->ScriptBufferId = entry->MainThreadGroupId & 0xFFFF;
         LoadScript(thd->ScriptBufferId, ScrWork[2004 + thd->ScriptBufferId]);
-        thd->Ip = ScriptBuffers[thd->ScriptBufferId] + entry->MainThreadIp;
+        thd->IpOffset = entry->MainThreadIp;
         // thd->CallStackDepth = entry->MainThreadCallStackDepth;
 
         LoadScript(entry->MainThreadReturnBufIds[0],
                    ScrWork[2004 + entry->MainThreadReturnBufIds[0]]);
         thd->CallStackDepth++;
         thd->ReturnScriptBufferIds[0] = entry->MainThreadReturnBufIds[0];
-        thd->ReturnAddresses[0] =
-            ScriptBuffers[entry->MainThreadReturnBufIds[0]] +
-            entry->MainThreadReturnIds[0];
+        thd->ReturnAddresses[0] = entry->MainThreadReturnIds[0];
 
         memcpy(thd->Variables, entry->MainThreadVariables, 64);
         thd->DialoguePageId = entry->MainThreadDialoguePageId;

--- a/src/games/mo6tw/sysmesbox.cpp
+++ b/src/games/mo6tw/sysmesbox.cpp
@@ -168,9 +168,10 @@ void SysMesBox::Init() {
   FadeAnimation.LoopMode = AnimationLoopMode::Stop;
 }
 
-void SysMesBox::AddMessage(uint8_t* str) {
+void SysMesBox::AddMessage(Vm::BufferOffsetContext ctx) {
   Impacto::Vm::Sc3VmThread dummy;
-  dummy.Ip = str;
+  dummy.IpOffset = ctx.IpOffset;
+  dummy.ScriptBufferId = ctx.ScriptBufferId;
   Messages[MessageCount] =
       TextLayoutPlainLine(&dummy, 255, Profile::Dialogue::DialogueFont,
                           TextFontSize, Profile::Dialogue::ColorTable[10], 1.0f,
@@ -183,9 +184,10 @@ void SysMesBox::AddMessage(uint8_t* str) {
   MessageCount++;
 }
 
-void SysMesBox::AddChoice(uint8_t* str) {
+void SysMesBox::AddChoice(Vm::BufferOffsetContext ctx) {
   Impacto::Vm::Sc3VmThread dummy;
-  dummy.Ip = str;
+  dummy.IpOffset = ctx.IpOffset;
+  dummy.ScriptBufferId = ctx.ScriptBufferId;
   Choices[ChoiceCount] =
       TextLayoutPlainLine(&dummy, 255, Profile::Dialogue::DialogueFont,
                           TextFontSize, Profile::Dialogue::ColorTable[10], 1.0f,

--- a/src/games/mo6tw/sysmesbox.h
+++ b/src/games/mo6tw/sysmesbox.h
@@ -15,8 +15,8 @@ class SysMesBox : public UI::SysMesBox {
   virtual void Render() override;
 
   virtual void Init() override;
-  virtual void AddMessage(uint8_t* str) override;
-  virtual void AddChoice(uint8_t* str) override;
+  virtual void AddMessage(Vm::BufferOffsetContext ctx) override;
+  virtual void AddChoice(Vm::BufferOffsetContext ctx) override;
 
  private:
   void ChoiceItemOnClick(UI::Widgets::Button* target);

--- a/src/games/mo6tw/tipsnotification.cpp
+++ b/src/games/mo6tw/tipsnotification.cpp
@@ -69,9 +69,10 @@ void TipsNotification::Update(float dt) {
   }
   if (FadeAnimation.IsIn() && Timer.IsOut()) {
     Timer.StartIn();
-    auto tipName = NotificationQueue.front();
-    TipName->SetText(tipName, FontSize, RendererOutlineMode::Full,
-                     TipNameColorIndex);
+    auto tipNameAdr = NotificationQueue.front();
+    auto tipsScrBufId = TipsSystem::GetTipsScriptBufferId();
+    TipName->SetText({.ScriptBufferId = tipsScrBufId, .IpOffset = tipNameAdr},
+                     FontSize, RendererOutlineMode::Full, TipNameColorIndex);
     TipName->MoveTo(
         glm::vec2(FinalNotificationPosition.x + TextPartBefore->Bounds.Width,
                   FinalNotificationPosition.y));
@@ -107,7 +108,7 @@ void TipsNotification::Render() {
 
 void TipsNotification::AddTip(int tipId) {
   auto record = TipsSystem::GetTipRecord(tipId);
-  NotificationQueue.push(record->StringPtrs[0]);
+  NotificationQueue.push(record->StringAdr[0]);
 }
 
 }  // namespace MO6TW

--- a/src/games/mo6tw/tipssystem.cpp
+++ b/src/games/mo6tw/tipssystem.cpp
@@ -13,17 +13,18 @@ using namespace Impacto::Vm;
 using namespace Impacto::Profile::TipsSystem;
 using namespace Impacto::Io;
 
-void TipsSystem::DataInit(int scriptBufferId, uint8_t *tipsData,
+void TipsSystem::DataInit(uint32_t scriptBufferId, uint32_t tipsDataAdr,
                           uint32_t tipsDataSize) {
   auto scriptBuffer = ScriptBuffers[scriptBufferId];
-
+  ScriptBufferId = static_cast<uint8_t>(scriptBufferId);
   // String of characters by which tips are sorted, taken from _system script
   // auto sortString = (uint16_t *)ScriptGetTextTableStrAddress(2, 5);
 
   int idx = 0;
 
   // Read tips data from the script and create UI elements for each tip
-  MemoryStream *stream = new MemoryStream(tipsData, tipsDataSize);
+  MemoryStream *stream =
+      new MemoryStream(&scriptBuffer[tipsDataAdr], tipsDataSize);
   auto unk01 = ReadLE<uint16_t>(stream);
   while (unk01 != 255) {
     // Read tip entry from the data array
@@ -35,8 +36,8 @@ void TipsSystem::DataInit(int scriptBufferId, uint8_t *tipsData,
     record.ThumbnailIndex = ReadLE<uint16_t>(stream);
     record.NumberOfContentStrings = ReadLE<uint16_t>(stream);
     for (int i = 0; i < record.NumberOfContentStrings + 3; i++) {
-      record.StringPtrs[i] =
-          ScriptGetStrAddress(scriptBuffer, ReadLE<uint16_t>(stream));
+      record.StringAdr[i] =
+          ScriptGetStrAddress(scriptBufferId, ReadLE<uint16_t>(stream));
     }
     Records[idx] = std::move(record);
 

--- a/src/games/mo6tw/tipssystem.h
+++ b/src/games/mo6tw/tipssystem.h
@@ -11,7 +11,7 @@ class TipsSystem : public TipsSystemBase {
  public:
   TipsSystem(int maxTipsCount) : TipsSystemBase(maxTipsCount) {};
 
-  void DataInit(int scriptBufferId, uint8_t* tipsData,
+  void DataInit(uint32_t scriptBufferId, uint32_t tipsDataAdr,
                 uint32_t tipsDataSize) override;
   void UpdateTipRecords() override;
   void SetTipLockedState(int id, bool state) override;

--- a/src/games/rne/sysmesbox.cpp
+++ b/src/games/rne/sysmesbox.cpp
@@ -282,9 +282,10 @@ void SysMesBox::Init() {
   FadeAnimation.LoopMode = AnimationLoopMode::Stop;
 }
 
-void SysMesBox::AddMessage(uint8_t* str) {
+void SysMesBox::AddMessage(Vm::BufferOffsetContext ctx) {
   Impacto::Vm::Sc3VmThread dummy;
-  dummy.Ip = str;
+  dummy.IpOffset = ctx.IpOffset;
+  dummy.ScriptBufferId = ctx.ScriptBufferId;
   Messages[MessageCount] =
       TextLayoutPlainLine(&dummy, 255, Profile::Dialogue::DialogueFont,
                           TextFontSize, Profile::Dialogue::ColorTable[10], 1.0f,
@@ -297,7 +298,7 @@ void SysMesBox::AddMessage(uint8_t* str) {
   MessageCount++;
 }
 
-void SysMesBox::AddChoice(uint8_t* str) {
+void SysMesBox::AddChoice(Vm::BufferOffsetContext ctx) {
   // No text based choices in R;NE
   ChoiceCount++;
 }

--- a/src/games/rne/sysmesbox.h
+++ b/src/games/rne/sysmesbox.h
@@ -15,8 +15,8 @@ class SysMesBox : public UI::SysMesBox {
   virtual void Render() override;
 
   virtual void Init() override;
-  virtual void AddMessage(uint8_t* str) override;
-  virtual void AddChoice(uint8_t* str) override;
+  virtual void AddMessage(Vm::BufferOffsetContext ctx) override;
+  virtual void AddChoice(Vm::BufferOffsetContext ctx) override;
 
  private:
   void ChoiceItemOnClick(UI::Widgets::Button* target);

--- a/src/hud/tipsnotification.h
+++ b/src/hud/tipsnotification.h
@@ -19,7 +19,7 @@ class TipsNotificationBase {
   Animation FadeAnimation;
 
  protected:
-  std::queue<uint8_t*> NotificationQueue;
+  std::queue<uint32_t> NotificationQueue;
 };
 
 inline TipsNotificationBase* Implementation = nullptr;

--- a/src/profile/games/mo6tw/musicmenu.cpp
+++ b/src/profile/games/mo6tw/musicmenu.cpp
@@ -45,7 +45,7 @@ void Configure() {
   {
     EnsurePushMemberOfType("Playlist", LUA_TTABLE);
 
-    auto size = lua_rawlen(LuaState, -1);
+    [[maybe_unused]] auto size = lua_rawlen(LuaState, -1);
     assert(size == MusicTrackCount);
     PushInitialIndex();
     while (PushNextTableElement() != 0) {

--- a/src/profile/profile_internal.h
+++ b/src/profile/profile_internal.h
@@ -241,7 +241,7 @@ std::vector<T> GetMemberVector(char const* name) {
   EnsurePushMemberOfType(name, LUA_TTABLE);
   PushInitialIndex();
   while (PushNextTableElement()) {
-    size_t i = EnsureGetKey<size_t>() - 1;
+    [[maybe_unused]] size_t i = EnsureGetKey<size_t>() - 1;
     assert(i == result.size());
     result.push_back(EnsureGetArrayElement<T>());
     Pop();

--- a/src/text.cpp
+++ b/src/text.cpp
@@ -1,3 +1,4 @@
+#include <memory>
 #include "text.h"
 #include "vm/expression.h"
 #include "log.h"
@@ -26,10 +27,9 @@
 
 #include <utf8.h>
 #include "vm/interface/input.h"
-#include <memory>
+#include "vm/sc3stream.h"
 
 namespace Impacto {
-
 using namespace Impacto::Profile::Dialogue;
 using namespace Impacto::Profile::ScriptVars;
 
@@ -72,13 +72,14 @@ struct StringToken {
   int Val_Expr;
 
   int Read(Vm::Sc3VmThread* ctx);
+  int Read(Vm::Sc3Stream& stream);
 };
 
 int StringToken::Read(Vm::Sc3VmThread* ctx) {
   int bytesRead = 0;
 
-  uint8_t c = *ctx->Ip;
-  ctx->Ip++;
+  uint8_t c = *ctx->GetIp();
+  ctx->IpOffset++;
   bytesRead++;
   switch (c) {
     case STT_LineBreak:
@@ -107,8 +108,8 @@ int StringToken::Read(Vm::Sc3VmThread* ctx) {
     case STT_GetHardcodedValue:
     case STT_UnlockTip: {
       Type = (StringTokenType)c;
-      Val_Uint16 = (*ctx->Ip << 8) | *(ctx->Ip + 1);
-      ctx->Ip += 2;
+      Val_Uint16 = (*ctx->GetIp() << 8) | *(ctx->GetIp() + 1);
+      ctx->IpOffset += 2;
       bytesRead += 2;
       break;
     }
@@ -116,24 +117,24 @@ int StringToken::Read(Vm::Sc3VmThread* ctx) {
     case STT_SetColor: {
       Type = (StringTokenType)c;
       if (ColorTagIsUint8) {
-        Val_Expr = (*(uint8_t*)(ctx->Ip));
-        ctx->Ip += 1;
+        Val_Expr = (*(uint8_t*)(ctx->GetIp()));
+        ctx->IpOffset += 1;
         bytesRead += 1;
       } else {
-        uint8_t* oldIp = ctx->Ip;
+        uint32_t oldIp = ctx->IpOffset;
         // TODO is this really okay to do in parsing code?
         Vm::ExpressionEval(ctx, &Val_Expr);
-        bytesRead += (int)(ctx->Ip - oldIp);
+        bytesRead += (int)(ctx->IpOffset - oldIp);
       }
       break;
     }
 
     case STT_EvaluateExpression: {
       Type = (StringTokenType)c;
-      uint8_t* oldIp = ctx->Ip;
+      uint32_t oldIp = ctx->IpOffset;
       // TODO is this really okay to do in parsing code?
       Vm::ExpressionEval(ctx, &Val_Expr);
-      bytesRead += (int)(ctx->Ip - oldIp);
+      bytesRead += (int)(ctx->IpOffset - oldIp);
       break;
     }
 
@@ -147,8 +148,8 @@ int StringToken::Read(Vm::Sc3VmThread* ctx) {
                "Encountered unrecognized token 0x{:02x} in string\n", c);
         Type = STT_EndOfString;
       } else {
-        uint16_t glyphId = (((uint16_t)c & 0x7F) << 8) | *ctx->Ip;
-        ctx->Ip++;
+        uint16_t glyphId = (((uint16_t)c & 0x7F) << 8) | *ctx->GetIp();
+        ctx->IpOffset++;
 
         Type = STT_Character;
         Val_Uint16 = glyphId;
@@ -158,6 +159,26 @@ int StringToken::Read(Vm::Sc3VmThread* ctx) {
   }
 
   return bytesRead;
+}
+
+int StringToken::Read(Vm::Sc3Stream& stream) {
+  uint8_t c = stream.ReadU8();
+  if (c == STT_Character) {
+    ImpLog(LogLevel::Error, LogChannel::VM,
+           "STT_Character encountered, uh oh...");
+  } else if (c < 0x80) {
+    ImpLog(LogLevel::Error, LogChannel::VM,
+           "Encountered non-character token 0x{:02x} in string\n", c);
+    Type = STT_EndOfString;
+  } else if (c == STT_EndOfString) {
+    Type = STT_EndOfString;
+  } else {
+    uint16_t glyphId = (((uint16_t)c & 0x7F) << 8) | stream.ReadU8();
+    Type = STT_Character;
+    Val_Uint16 = glyphId;
+    return 2;
+  }
+  return 1;
 }
 
 uint8_t ProcessedTextGlyph::Flags() const {
@@ -285,8 +306,7 @@ void DialoguePage::FinishLine(Vm::Sc3VmThread* ctx, int nextLineStart,
   for (size_t i = FirstRubyChunkOnLine; i < RubyChunkCount; i++) {
     if (RubyChunks[i].FirstBaseCharacter >= nextLineStart) break;
 
-    uint8_t* oldIp = ctx->Ip;
-    ctx->Ip = (uint8_t*)RubyChunks[i].RawText;
+    Vm::Sc3Stream rubyText(RubyChunks[i].RawText);
 
     glm::vec2 pos =
         glm::vec2(0, CurrentLineTop + CurrentLineTopMargin + RubyYOffset);
@@ -294,8 +314,8 @@ void DialoguePage::FinishLine(Vm::Sc3VmThread* ctx, int nextLineStart,
     // ruby base length > ruby text length: block align
     // ruby base length > ruby text length and 0x1E: center per character
     // ruby base length == ruby text length: center per character
-    // ruby base length < ruby text length: center over block (handled by block
-    // align)
+    // ruby base length < ruby text length: center over block (handled by
+    // block align)
 
     if (RubyChunks[i].Length == RubyChunks[i].BaseLength ||
         (RubyChunks[i].CenterPerCharacter &&
@@ -305,7 +325,7 @@ void DialoguePage::FinishLine(Vm::Sc3VmThread* ctx, int nextLineStart,
         RectF const& baseGlyphRect =
             Glyphs[RubyChunks[i].FirstBaseCharacter + j].DestRect;
         pos.x = baseGlyphRect.Center().x;
-        TextLayoutPlainLine(ctx, 1, std::span(RubyChunks[i].Text + j, 1),
+        TextLayoutPlainLine(rubyText, 1, std::span(RubyChunks[i].Text + j, 1),
                             DialogueFont, RubyFontSize, ColorTable[0], 1.0f,
                             pos, TextAlignment::Center);
       }
@@ -329,9 +349,6 @@ void DialoguePage::FinishLine(Vm::Sc3VmThread* ctx, int nextLineStart,
                             pos, TextAlignment::Block, blockWidth);
     */
     }
-
-    ctx->Ip = oldIp;
-
     FirstRubyChunkOnLine++;
   }
 
@@ -407,8 +424,8 @@ void DialoguePage::AddString(Vm::Sc3VmThread* ctx, Audio::AudioStream* voice,
   size_t typewriterStart = Glyphs.size();
 
   // TODO should we reset HasName here?
-  // It shouldn't really matter since names are an ADV thing and we clear before
-  // every add on ADV anyway...
+  // It shouldn't really matter since names are an ADV thing and we clear
+  // before every add on ADV anyway...
 
   AutoForward = false;
 
@@ -479,8 +496,8 @@ void DialoguePage::AddString(Vm::Sc3VmThread* ctx, Audio::AudioStream* voice,
         break;
       }
       case STT_RubyTextEnd: {
-        // At least S;G uses [ruby-base]link text[ruby-text-end] for mails, with
-        // no ruby-text-start
+        // At least S;G uses [ruby-base]link text[ruby-text-end] for mails,
+        // with no ruby-text-start
         EndRubyBase((int)Glyphs.size() - 1);
         State = TPS_Normal;
         break;
@@ -639,9 +656,6 @@ void DialoguePage::AddString(Vm::Sc3VmThread* ctx, Audio::AudioStream* voice,
   }
 
   if (HasName) {
-    uint8_t* oldIp = ctx->Ip;
-    ctx->Ip = (uint8_t*)name;
-
     NameId = GetNameId((uint8_t*)name, NameLength * 2);
 
     float fontSize = ADVNameFontSize;
@@ -664,11 +678,10 @@ void DialoguePage::AddString(Vm::Sc3VmThread* ctx, Audio::AudioStream* voice,
           break;
       }
     }
-
-    Name = TextLayoutPlainLine(ctx, NameLength, DialogueFont, fontSize,
+    Vm::Sc3Stream nameStream(name);
+    Name = TextLayoutPlainLine(nameStream, NameLength, DialogueFont, fontSize,
                                ColorTable[colorIndex], 1.0f, pos, alignment);
     assert(NameLength == Name.size());
-    ctx->Ip = oldIp;
   }
 
   if (voice != 0) {
@@ -767,6 +780,14 @@ void DialoguePage::MoveTo(glm::vec2 pos) {
   Move(relativePos);
 }
 
+int TextGetStringLength(Vm::Sc3Stream& stream) {
+  int result = 0;
+  StringToken token;
+  do {
+    result += token.Read(stream);
+  } while (token.Type != STT_EndOfString);
+  return result;
+}
 int TextGetStringLength(Vm::Sc3VmThread* ctx) {
   int result = 0;
   StringToken token;
@@ -775,12 +796,13 @@ int TextGetStringLength(Vm::Sc3VmThread* ctx) {
   } while (token.Type != STT_EndOfString);
   return result;
 }
-/*
+
 int TextGetMainCharacterCount(Vm::Sc3VmThread* ctx) {
   int result = 0;
-  StringToken token;  // FIXME: Initialize token
+  StringToken token;
   bool isMain = true;
   do {
+    token.Read(ctx);
     switch (token.Type) {
       case STT_CharacterNameStart:
       case STT_RubyTextStart: {
@@ -802,60 +824,28 @@ int TextGetMainCharacterCount(Vm::Sc3VmThread* ctx) {
   } while (token.Type != STT_EndOfString);
   return result;
 }
-*/
 
-int TextLayoutPlainLine(Vm::Sc3VmThread* ctx, int stringLength,
-                        std::span<ProcessedTextGlyph> outGlyphs, Font* font,
-                        float fontSize, DialogueColorPair colors, float opacity,
-                        glm::vec2 pos, TextAlignment alignment,
-                        float blockWidth) {
-  int characterCount = 0;
-  StringToken token;
+template <typename T>
+concept Sc3Type =
+    std::is_lvalue_reference_v<T> &&
+        std::is_base_of_v<Vm::Sc3Stream, std::remove_reference_t<T>> ||
+    std::is_same_v<std::decay_t<T>, Vm::Sc3VmThread*>;
 
-  float currentX = 0;
-  for (int i = 0; i < stringLength; i++) {
-    token.Read(ctx);
-    if (token.Type == STT_EndOfString) break;
-    if (token.Type != STT_Character) continue;
-
-    ProcessedTextGlyph& ptg = outGlyphs[characterCount];
-    ptg.CharId = token.Val_Uint16;
-    ptg.Colors = colors;
-    ptg.Opacity = opacity;
-
-    ptg.DestRect.X = currentX;
-    ptg.DestRect.Y = pos.y;
-    ptg.DestRect.Width = std::floor((fontSize / font->BitmapEmWidth) *
-                                    font->AdvanceWidths[ptg.CharId]);
-    ptg.DestRect.Height = fontSize;
-
-    currentX += ptg.DestRect.Width;
-
-    characterCount++;
-  }
-  assert(outGlyphs.size() >= characterCount);
-  // currentX is now line width
-  return TextLayoutAlignment(alignment, blockWidth, currentX, pos,
-                             characterCount, outGlyphs);
-}
-
-std::vector<ProcessedTextGlyph> TextLayoutPlainLine(
-    Vm::Sc3VmThread* ctx, int maxLength, Font* font, float fontSize,
-    DialogueColorPair colors, float opacity, glm::vec2 pos,
+std::pair<int, float> TextLayoutPlainLineHelper(
+    Sc3Type auto&& sc3, int stringLength,
+    std::output_iterator<ProcessedTextGlyph> auto outIt, Font* font,
+    float fontSize, DialogueColorPair colors, float opacity, glm::vec2 pos,
     TextAlignment alignment, float blockWidth) {
   int characterCount = 0;
   StringToken token;
 
   float currentX = 0;
-  std::vector<ProcessedTextGlyph> outGlyphs;
-  outGlyphs.reserve(maxLength);
-  for (int i = 0; i < maxLength; i++) {
-    token.Read(ctx);
+  for (int i = 0; i < stringLength; i++) {
+    token.Read(sc3);
     if (token.Type == STT_EndOfString) break;
     if (token.Type != STT_Character) continue;
 
-    outGlyphs.push_back(ProcessedTextGlyph());
-    ProcessedTextGlyph& ptg = outGlyphs.back();
+    ProcessedTextGlyph ptg;
     ptg.CharId = token.Val_Uint16;
     ptg.Colors = colors;
     ptg.Opacity = opacity;
@@ -868,12 +858,64 @@ std::vector<ProcessedTextGlyph> TextLayoutPlainLine(
 
     currentX += ptg.DestRect.Width;
 
+    *outIt++ = ptg;
     characterCount++;
   }
-
   // currentX is now line width
-  TextLayoutAlignment(alignment, blockWidth, currentX, pos, characterCount,
-                      outGlyphs);
+  // If you want to align, you can pass a span or vector to the alignment
+  // function
+  return {characterCount, currentX};
+}
+
+int TextLayoutPlainLine(Vm::Sc3Stream& stream, int stringLength,
+                        std::span<ProcessedTextGlyph> outGlyphs, Font* font,
+                        float fontSize, DialogueColorPair colors, float opacity,
+                        glm::vec2 pos, TextAlignment alignment,
+                        float blockWidth) {
+  auto [count, currentX] = TextLayoutPlainLineHelper(
+      stream, stringLength, outGlyphs.begin(), font, fontSize, colors, opacity,
+      pos, alignment, blockWidth);
+  assert(outGlyphs.size() >= count);
+  TextLayoutAlignment(alignment, blockWidth, currentX, pos, count, outGlyphs);
+  return count;
+}
+
+std::vector<ProcessedTextGlyph> TextLayoutPlainLine(
+    Vm::Sc3Stream& stream, int maxLength, Font* font, float fontSize,
+    DialogueColorPair colors, float opacity, glm::vec2 pos,
+    TextAlignment alignment, float blockWidth) {
+  std::vector<ProcessedTextGlyph> outGlyphs;
+  outGlyphs.reserve(maxLength);
+  auto [count, currentX] = TextLayoutPlainLineHelper(
+      stream, maxLength, std::back_inserter(outGlyphs), font, fontSize, colors,
+      opacity, pos, alignment, blockWidth);
+  TextLayoutAlignment(alignment, blockWidth, currentX, pos, count, outGlyphs);
+  return outGlyphs;
+}
+
+int TextLayoutPlainLine(Vm::Sc3VmThread* thd, int stringLength,
+                        std::span<ProcessedTextGlyph> outGlyphs, Font* font,
+                        float fontSize, DialogueColorPair colors, float opacity,
+                        glm::vec2 pos, TextAlignment alignment,
+                        float blockWidth) {
+  auto [count, currentX] = TextLayoutPlainLineHelper(
+      thd, stringLength, outGlyphs.begin(), font, fontSize, colors, opacity,
+      pos, alignment, blockWidth);
+  assert(outGlyphs.size() >= count);
+  TextLayoutAlignment(alignment, blockWidth, currentX, pos, count, outGlyphs);
+  return count;
+}
+
+std::vector<ProcessedTextGlyph> TextLayoutPlainLine(
+    Vm::Sc3VmThread* thd, int maxLength, Font* font, float fontSize,
+    DialogueColorPair colors, float opacity, glm::vec2 pos,
+    TextAlignment alignment, float blockWidth) {
+  std::vector<ProcessedTextGlyph> outGlyphs;
+  outGlyphs.reserve(maxLength);
+  auto [count, currentX] = TextLayoutPlainLineHelper(
+      thd, maxLength, std::back_inserter(outGlyphs), font, fontSize, colors,
+      opacity, pos, alignment, blockWidth);
+  TextLayoutAlignment(alignment, blockWidth, currentX, pos, count, outGlyphs);
   return outGlyphs;
 }
 
@@ -947,6 +989,22 @@ float TextGetPlainLineWidth(Vm::Sc3VmThread* ctx, Font* font, float fontSize) {
   return width;
 }
 
+float TextGetPlainLineWidth(Vm::Sc3Stream& stream, Font* font, float fontSize) {
+  StringToken token;
+
+  float width = 0.0f;
+  while (true) {
+    token.Read(stream);
+    if (token.Type == STT_EndOfString) break;
+    if (token.Type != STT_Character) continue;
+
+    width += std::floor((fontSize / font->BitmapEmWidth) *
+                        font->AdvanceWidths[token.Val_Uint16]);
+  }
+
+  return width;
+}
+
 int TextLayoutPlainString(std::string_view str,
                           std::span<ProcessedTextGlyph> outGlyphs, Font* font,
                           float fontSize, DialogueColorPair colors,
@@ -961,9 +1019,8 @@ int TextLayoutPlainString(std::string_view str,
   TextGetSc3String(str,
                    std::span(sc3StrPtr.get(), sc3StrPtr.get() + sc3StrLength));
 
-  Vm::Sc3VmThread dummy;
-  dummy.Ip = reinterpret_cast<uint8_t*>(sc3StrPtr.get());
-  return TextLayoutPlainLine(&dummy, sc3StrLength, outGlyphs, font, fontSize,
+  Vm::Sc3Stream stream(sc3StrPtr.get());
+  return TextLayoutPlainLine(stream, sc3StrLength, outGlyphs, font, fontSize,
                              colors, opacity, pos, alignment, blockWidth);
 }
 
@@ -979,9 +1036,8 @@ std::vector<ProcessedTextGlyph> TextLayoutPlainString(
   TextGetSc3String(str,
                    std::span(sc3StrPtr.get(), sc3StrPtr.get() + sc3StrLength));
 
-  Vm::Sc3VmThread dummy;
-  dummy.Ip = reinterpret_cast<uint8_t*>(sc3StrPtr.get());
-  return TextLayoutPlainLine(&dummy, sc3StrLength, font, fontSize, colors,
+  Vm::Sc3Stream stream(sc3StrPtr.get());
+  return TextLayoutPlainLine(stream, sc3StrLength, font, fontSize, colors,
                              opacity, pos, alignment, blockWidth);
 }
 
@@ -1003,20 +1059,20 @@ void TextGetSc3String(std::string_view str, std::span<uint16_t> out) {
   assert(sc3Idx == sc3StrLength);
 }
 
-void InitNamePlateData(uint16_t* data) {
-  int idx = 0;
+void InitNamePlateData(Vm::Sc3Stream& stream) {
   do {
-    uint16_t id = data[idx];
-    uint16_t stringId = data[idx + 1];
-    idx += 2;
-    uint8_t* name = Vm::ScriptGetStrAddress(
-        Vm::ScriptBuffers[Profile::Vm::SystemScriptBuffer], stringId);
+    uint16_t id = stream.ReadU16();
+    uint16_t stringId = stream.ReadU16();
+    uint32_t nameAddr =
+        Vm::ScriptGetStrAddress(Profile::Vm::SystemScriptBuffer, stringId);
     Vm::Sc3VmThread dummy;
-    dummy.Ip = name;
+    dummy.IpOffset = nameAddr;
+    dummy.ScriptBufferId = Profile::Vm::SystemScriptBuffer;
     int nameLength = (TextGetStringLength(&dummy) - 1) * 2;
-    uint32_t nameHash = GetHashCode(name, nameLength);
+    dummy.IpOffset = nameAddr;
+    uint32_t nameHash = GetHashCode(dummy.GetIp(), nameLength);
     NamePlateData[nameHash] = id;
-  } while (data[idx] != 0xFFFF);
+  } while (stream.PeekU16() != 0xFFFF);
 }
 
 uint32_t GetNameId(uint8_t* name, int nameLength) {

--- a/src/text.cpp
+++ b/src/text.cpp
@@ -1045,7 +1045,7 @@ void TextGetSc3String(std::string_view str, std::span<uint16_t> out) {
   std::string_view::iterator strIt = str.begin();
   std::string_view::iterator strEnd = str.end();
 
-  int sc3StrLength = (int)utf8::distance(strIt, strEnd) + 1;
+  [[maybe_unused]] int sc3StrLength = (int)utf8::distance(strIt, strEnd) + 1;
   assert(sc3StrLength <= out.size());
   int sc3Idx = 0;
   while (strIt != strEnd) {

--- a/src/text.h
+++ b/src/text.h
@@ -1,15 +1,16 @@
 #pragma once
 
-#include "font.h"
-#include "animation.h"
-#include "vm/thread.h"
+#include <span>
 #include <enum.h>
 #include <ankerl/unordered_dense.h>
 
+#include "font.h"
+#include "animation.h"
+#include "vm/thread.h"
+#include "vm/sc3stream.h"
 #include "audio/audiosystem.h"
 #include "audio/audiostream.h"
 #include "audio/audiochannel.h"
-#include <span>
 
 namespace Impacto {
 
@@ -134,21 +135,32 @@ struct DialoguePage {
 inline DialoguePage* DialoguePages;
 inline int DialoguePageCount = 0;
 
+int TextGetStringLength(Vm::Sc3Stream& stream);
 int TextGetStringLength(Vm::Sc3VmThread* ctx);
 [[maybe_unused]] int TextGetMainCharacterCount(Vm::Sc3VmThread* ctx);
+int TextLayoutPlainLine(Vm::Sc3Stream& stream, int stringLength,
+                        std::span<ProcessedTextGlyph> outGlyphs, Font* font,
+                        float fontSize, DialogueColorPair colors, float opacity,
+                        glm::vec2 pos, TextAlignment alignment,
+                        float blockWidth = 0.0f);
 int TextLayoutPlainLine(Vm::Sc3VmThread* ctx, int stringLength,
                         std::span<ProcessedTextGlyph> outGlyphs, Font* font,
                         float fontSize, DialogueColorPair colors, float opacity,
                         glm::vec2 pos, TextAlignment alignment,
                         float blockWidth = 0.0f);
 std::vector<ProcessedTextGlyph> TextLayoutPlainLine(
-    Vm::Sc3VmThread* ctx, int maxLength, Font* font, float fontSize,
+    Vm::Sc3Stream& stream, int maxLength, Font* font, float fontSize,
+    DialogueColorPair colors, float opacity, glm::vec2 pos,
+    TextAlignment alignment, float blockWidth = 0.0f);
+std::vector<ProcessedTextGlyph> TextLayoutPlainLine(
+    Vm::Sc3VmThread* thd, int maxLength, Font* font, float fontSize,
     DialogueColorPair colors, float opacity, glm::vec2 pos,
     TextAlignment alignment, float blockWidth = 0.0f);
 int TextLayoutAlignment(Impacto::TextAlignment& alignment, float blockWidth,
                         float currentX, glm::vec2& pos, int characterCount,
                         std::span<Impacto::ProcessedTextGlyph> outGlyphs);
 float TextGetPlainLineWidth(Vm::Sc3VmThread* ctx, Font* font, float fontSize);
+float TextGetPlainLineWidth(Vm::Sc3Stream& stream, Font* font, float fontSize);
 int TextLayoutPlainString(std::string_view str,
                           std::span<ProcessedTextGlyph> outGlyphs, Font* font,
                           float fontSize, DialogueColorPair colors,
@@ -162,7 +174,7 @@ std::vector<ProcessedTextGlyph> TextLayoutPlainString(
 void TextGetSc3String(std::string_view str, std::span<uint16_t> out);
 
 inline ankerl::unordered_dense::map<uint32_t, uint32_t> NamePlateData;
-void InitNamePlateData(uint16_t* data);
+void InitNamePlateData(Vm::Sc3Stream& stream);
 uint32_t GetNameId(uint8_t* name, int nameLength);
 
 // Bitfield denoting the skip mode, according to SkipModeFlags

--- a/src/texture/gxtloader.cpp
+++ b/src/texture/gxtloader.cpp
@@ -366,7 +366,7 @@ bool TextureLoadGXT(Stream* stream, Texture* outTexture) {
 
   uint32_t version = ReadLE<uint32_t>(stream);
   (void)version;
-  uint32_t subtextureCount = ReadLE<uint32_t>(stream);
+  [[maybe_unused]] uint32_t subtextureCount = ReadLE<uint32_t>(stream);
   assert(subtextureCount == 1);
   uint32_t subtexturesOffset = ReadLE<uint32_t>(stream);
   (void)subtexturesOffset;

--- a/src/ui/backlogmenu.cpp
+++ b/src/ui/backlogmenu.cpp
@@ -286,12 +286,13 @@ void BacklogMenu::RenderHighlight() const {
 
 void BacklogMenu::Render() {}
 
-void BacklogMenu::AddMessage(uint8_t* str, int audioId, int characterId) {
+void BacklogMenu::AddMessage(Vm::BufferOffsetContext scrCtx, int audioId,
+                             int characterId) {
   if (!GetFlag(SF_REVADDDISABLE) || ScrWork[SW_MESWIN0TYPE] == 0) {
     auto onClick = [this](auto* btn) { return MenuButtonOnClick(btn); };
 
     Widgets::BacklogEntry* backlogEntry = CreateBacklogEntry(
-        CurrentId, str, audioId, characterId, CurrentEntryPos, HoverBounds);
+        CurrentId, scrCtx, audioId, characterId, CurrentEntryPos, HoverBounds);
     backlogEntry->OnClickHandler = onClick;
     MainItems->Add(backlogEntry, FDIR_DOWN);
     CurrentId++;

--- a/src/ui/backlogmenu.h
+++ b/src/ui/backlogmenu.h
@@ -20,13 +20,14 @@ class BacklogMenu : public Menu {
   virtual void Render();
 
   virtual Widgets::BacklogEntry* CreateBacklogEntry(
-      int id, uint8_t* str, int audioId, int characterId, glm::vec2 pos,
-      const RectF& hoverBounds) const {
-    return new Widgets::BacklogEntry(id, str, audioId, characterId, pos,
+      int id, Vm::BufferOffsetContext scrCtx, int audioId, int characterId,
+      glm::vec2 pos, const RectF& hoverBounds) const {
+    return new Widgets::BacklogEntry(id, scrCtx, audioId, characterId, pos,
                                      hoverBounds);
   }
 
-  virtual void AddMessage(uint8_t* str, int audioId = -1, int characterId = 0);
+  virtual void AddMessage(Vm::BufferOffsetContext scrCtx, int audioId = -1,
+                          int characterId = 0);
   virtual void MenuButtonOnClick(Widgets::BacklogEntry* target);
   void Clear();
 

--- a/src/ui/selectionmenu.cpp
+++ b/src/ui/selectionmenu.cpp
@@ -30,9 +30,10 @@ void SelectionMenu::Init(bool isPlain) {
   FadeAnimation.LoopMode = AnimationLoopMode::Stop;
 }
 
-void SelectionMenu::AddChoice(uint8_t* str) {
+void SelectionMenu::AddChoice(Vm::BufferOffsetContext ctx) {
   Impacto::Vm::Sc3VmThread dummy;
-  dummy.Ip = str;
+  dummy.IpOffset = ctx.IpOffset;
+  dummy.ScriptBufferId = ctx.ScriptBufferId;
   Choices[ChoiceCount] = TextLayoutPlainLine(
       &dummy, 255, Profile::Dialogue::DialogueFont,
       Profile::Dialogue::DefaultFontSize, Profile::Dialogue::ColorTable[0],

--- a/src/ui/selectionmenu.h
+++ b/src/ui/selectionmenu.h
@@ -16,7 +16,7 @@ class SelectionMenu : public Menu {
   void Render();
 
   void Init(bool isPlain);
-  void AddChoice(uint8_t* str);
+  void AddChoice(Vm::BufferOffsetContext ctx);
 
   void ChoiceItemOnClick(Widgets::Button* target);
 

--- a/src/ui/sysmesbox.cpp
+++ b/src/ui/sysmesbox.cpp
@@ -8,8 +8,8 @@ void SysMesBox::Hide() {}
 void SysMesBox::Update(float dt) {}
 void SysMesBox::Render() {}
 void SysMesBox::Init() {}
-void SysMesBox::AddMessage(uint8_t* str) {}
-void SysMesBox::AddChoice(uint8_t* str) {}
+void SysMesBox::AddMessage(Vm::BufferOffsetContext) {}
+void SysMesBox::AddChoice(Vm::BufferOffsetContext) {}
 
 }  // namespace UI
 }  // namespace Impacto

--- a/src/ui/sysmesbox.h
+++ b/src/ui/sysmesbox.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "menu.h"
+#include "../vm/vm.h"
 #include "../text.h"
 #include "../ui/widgets/group.h"
 
@@ -15,8 +16,8 @@ class SysMesBox : public Menu {
   virtual void Render();
 
   virtual void Init();
-  virtual void AddMessage(uint8_t* str);
-  virtual void AddChoice(uint8_t* str);
+  virtual void AddMessage(Vm::BufferOffsetContext str);
+  virtual void AddChoice(Vm::BufferOffsetContext str);
 
   int MessageCount;
   int ChoiceCount;

--- a/src/ui/widgets/backlogentry.cpp
+++ b/src/ui/widgets/backlogentry.cpp
@@ -14,8 +14,9 @@ namespace Widgets {
 
 using namespace Impacto::Profile::BacklogMenu;
 
-BacklogEntry::BacklogEntry(int id, uint8_t* str, int audioId, int characterId,
-                           glm::vec2 pos, const RectF& hoverBounds)
+BacklogEntry::BacklogEntry(int id, Vm::BufferOffsetContext scrCtx, int audioId,
+                           int characterId, glm::vec2 pos,
+                           const RectF& hoverBounds)
     : Id(id),
       AudioId(audioId),
       CharacterId(characterId),
@@ -29,7 +30,8 @@ BacklogEntry::BacklogEntry(int id, uint8_t* str, int audioId, int characterId,
   BacklogPage->Mode = DPM_REV;
 
   Impacto::Vm::Sc3VmThread dummy;
-  dummy.Ip = str;
+  dummy.IpOffset = scrCtx.IpOffset;
+  dummy.ScriptBufferId = scrCtx.ScriptBufferId;
   // CHLCC uses DPM_REV for the Erin DialogueBox
   if (Profile::Dialogue::DialogueBoxCurrentType != +DialogueBoxType::CHLCC) {
     Profile::Dialogue::REVBounds.X = pos.x;

--- a/src/ui/widgets/backlogentry.h
+++ b/src/ui/widgets/backlogentry.h
@@ -4,6 +4,7 @@
 
 #include "../widget.h"
 #include "../../text.h"
+#include "../../vm/vm.h"
 
 namespace Impacto {
 namespace UI {
@@ -11,8 +12,8 @@ namespace Widgets {
 
 class BacklogEntry : public Widget {
  public:
-  BacklogEntry(int id, uint8_t* str, int audioId, int characterId,
-               glm::vec2 pos, const RectF& hoverBounds);
+  BacklogEntry(int id, Vm::BufferOffsetContext scrCtx, int audioId,
+               int characterId, glm::vec2 pos, const RectF& hoverBounds);
   ~BacklogEntry();
 
   void UpdateInput() override;

--- a/src/ui/widgets/button.cpp
+++ b/src/ui/widgets/button.cpp
@@ -71,14 +71,36 @@ void Button::Render() {
   }
 }
 
-void Button::SetText(uint8_t* str, float fontSize,
+void Button::SetText(Vm::BufferOffsetContext scrCtx, float fontSize,
                      RendererOutlineMode outlineMode,
                      DialogueColorPair colorPair) {
   HasText = true;
   Impacto::Vm::Sc3VmThread dummy;
-  dummy.Ip = str;
+  dummy.IpOffset = scrCtx.IpOffset;
+  dummy.ScriptBufferId = scrCtx.ScriptBufferId;
   Text = TextLayoutPlainLine(
       &dummy, 255, Profile::Dialogue::DialogueFont, fontSize, colorPair, 1.0f,
+      glm::vec2(Bounds.X, Bounds.Y), TextAlignment::Left);
+  OutlineMode = outlineMode;
+  TextWidth = 0.0f;
+  for (int i = 0; i < Text.size(); i++) {
+    TextWidth += Text[i].DestRect.Width;
+  }
+  Bounds = RectF(Text[0].DestRect.X, Text[0].DestRect.Y, TextWidth, fontSize);
+  HoverBounds = Bounds;
+}
+void Button::SetText(Vm::BufferOffsetContext scrCtx, float fontSize,
+                     RendererOutlineMode outlineMode, int colorIndex) {
+  SetText(scrCtx, fontSize, outlineMode,
+          Profile::Dialogue::ColorTable[colorIndex]);
+}
+
+void Button::SetText(Vm::Sc3Stream& stream, float fontSize,
+                     RendererOutlineMode outlineMode,
+                     DialogueColorPair colorPair) {
+  HasText = true;
+  Text = TextLayoutPlainLine(
+      stream, 255, Profile::Dialogue::DialogueFont, fontSize, colorPair, 1.0f,
       glm::vec2(Bounds.X, Bounds.Y), TextAlignment::Left);
   OutlineMode = outlineMode;
   for (int i = 0; i < Text.size(); i++) {
@@ -88,9 +110,9 @@ void Button::SetText(uint8_t* str, float fontSize,
   HoverBounds = Bounds;
 }
 
-void Button::SetText(uint8_t* str, float fontSize,
+void Button::SetText(Vm::Sc3Stream& stream, float fontSize,
                      RendererOutlineMode outlineMode, int colorIndex) {
-  SetText(str, fontSize, outlineMode,
+  SetText(stream, fontSize, outlineMode,
           Profile::Dialogue::ColorTable[colorIndex]);
 }
 

--- a/src/ui/widgets/button.h
+++ b/src/ui/widgets/button.h
@@ -24,10 +24,14 @@ class Button : public Widget {
   virtual void MoveTo(glm::vec2 pos) override;
   virtual void MoveTo(glm::vec2 pos, float duration) override;
 
-  void SetText(uint8_t* str, float fontSize, RendererOutlineMode outlineMode,
-               int colorIndex = 10);
-  void SetText(uint8_t* str, float fontSize, RendererOutlineMode outlineMode,
-               DialogueColorPair colorPair);
+  void SetText(Vm::BufferOffsetContext scrCtx, float fontSize,
+               RendererOutlineMode outlineMode, int colorIndex = 10);
+  void SetText(Vm::BufferOffsetContext scrCtx, float fontSize,
+               RendererOutlineMode outlineMode, DialogueColorPair colorPair);
+  void SetText(Vm::Sc3Stream& stream, float fontSize,
+               RendererOutlineMode outlineMode, int colorIndex = 10);
+  void SetText(Vm::Sc3Stream& stream, float fontSize,
+               RendererOutlineMode outlineMode, DialogueColorPair colorPair);
   void SetText(std::vector<ProcessedTextGlyph> text, float textWidth,
                float fontSize, RendererOutlineMode outlineMode);
   void ClearText() {

--- a/src/ui/widgets/cclcc/saveentrybutton.cpp
+++ b/src/ui/widgets/cclcc/saveentrybutton.cpp
@@ -154,8 +154,7 @@ void SaveEntryButton::MoveTo(glm::vec2 position) {
 }
 
 void SaveEntryButton::RefreshCharacterRouteText(int strIndex) {
-  // TODO actually make this look correct
-  uint8_t* strAddr = Vm::ScriptGetTextTableStrAddress(1, strIndex);
+  auto strAddr = Vm::ScriptGetTextTableStrAddress(1, strIndex);
   float fontSize = 28;
   RendererOutlineMode outlineMode = RendererOutlineMode::Full;
   CharacterRouteLabel.SetText(strAddr, fontSize, outlineMode,
@@ -163,8 +162,7 @@ void SaveEntryButton::RefreshCharacterRouteText(int strIndex) {
 }
 
 void SaveEntryButton::RefreshSceneTitleText(int strIndex) {
-  // TODO actually make this look correct
-  uint8_t* strAddr = Vm::ScriptGetTextTableStrAddress(1, strIndex + 1);
+  auto strAddr = Vm::ScriptGetTextTableStrAddress(1, strIndex + 1);
   float fontSize = 28;
   RendererOutlineMode outlineMode = RendererOutlineMode::Full;
   SceneTitleLabel.SetText(strAddr, fontSize, outlineMode,

--- a/src/ui/widgets/cclcc/tipsentrybutton.cpp
+++ b/src/ui/widgets/cclcc/tipsentrybutton.cpp
@@ -33,8 +33,9 @@ TipsEntryButton::TipsEntryButton(int tipId, int dispId, RectF const& dest,
                         glm::vec2(Bounds.X, Bounds.Y) + TipsEntryNumberOffset,
                         TextAlignment::Left);
   Vm::Sc3VmThread dummy;
+  dummy.ScriptBufferId = TipsSystem::GetTipsScriptBufferId();
   glm::vec2 nameDest = glm::vec2(Bounds.X, Bounds.Y) + TipsEntryNameOffset;
-  dummy.Ip = TipEntryRecord->StringPtrs[1];
+  dummy.IpOffset = TipEntryRecord->StringAdr[1];
   HasText = true;
 
   uint32_t initColorName =
@@ -43,9 +44,8 @@ TipsEntryButton::TipsEntryButton(int tipId, int dispId, RectF const& dest,
                              (float)TipsEntryNameFontSize, {initColorName, 0},
                              1.0f, nameDest, TextAlignment::Left);
 
-  dummy.Ip = Vm::ScriptGetStrAddress(
-      Impacto::Vm::ScriptBuffers[TipsSystem::GetTipsScriptBufferId()],
-      TipsTextEntryLockedIndex);
+  dummy.IpOffset = Vm::ScriptGetStrAddress(TipsSystem::GetTipsScriptBufferId(),
+                                           TipsTextEntryLockedIndex);
   TextLayoutPlainLine(&dummy, TipLockedTextLength, TipLockedText,
                       Profile::Dialogue::DialogueFont,
                       (float)TipsEntryNameFontSize, {initColorName, 0}, 1.0f,

--- a/src/ui/widgets/chlcc/saveentrybutton.cpp
+++ b/src/ui/widgets/chlcc/saveentrybutton.cpp
@@ -52,11 +52,13 @@ void SaveEntryButton::AddNormalSpriteLabel(Sprite norm, glm::vec2 pos) {
   NormalSpriteLabel = Label(norm, pos);
 }
 
-void SaveEntryButton::AddEntryNumberHintText(uint8_t* str, float fontSize,
+void SaveEntryButton::AddEntryNumberHintText(Vm::BufferOffsetContext strAdr,
+                                             float fontSize,
                                              RendererOutlineMode outlineMode,
                                              glm::vec2 relativePosition) {
-  EntryNumberHint = Label(str, glm::vec2(Bounds.X, Bounds.Y) + relativePosition,
-                          fontSize, outlineMode, IsLocked ? 69 : 0);
+  EntryNumberHint =
+      Label(strAdr, glm::vec2(Bounds.X, Bounds.Y) + relativePosition, fontSize,
+            outlineMode, IsLocked ? 69 : 0);
 }
 
 void SaveEntryButton::AddEntryNumberText(std::string_view str, float fontSize,
@@ -66,25 +68,27 @@ void SaveEntryButton::AddEntryNumberText(std::string_view str, float fontSize,
                       fontSize, outlineMode, IsLocked ? 69 : 0);
 }
 
-void SaveEntryButton::AddSceneTitleText(uint8_t* str, float fontSize,
+void SaveEntryButton::AddSceneTitleText(Vm::BufferOffsetContext strAdr,
+                                        float fontSize,
                                         RendererOutlineMode outlineMode,
                                         glm::vec2 relativeTitlePosition,
                                         glm::vec2 relativeNoDataPosition) {
   if (EntryActive) {
     SceneTitle =
-        Label(str, glm::vec2(Bounds.X, Bounds.Y) + relativeTitlePosition,
+        Label(strAdr, glm::vec2(Bounds.X, Bounds.Y) + relativeTitlePosition,
               fontSize, outlineMode, IsLocked ? 69 : 0);
   } else {
     SceneTitle =
-        Label(str, glm::vec2(Bounds.X, Bounds.Y) + relativeNoDataPosition,
+        Label(strAdr, glm::vec2(Bounds.X, Bounds.Y) + relativeNoDataPosition,
               fontSize, outlineMode, 0);
   }
 }
 
-void SaveEntryButton::AddPlayTimeHintText(uint8_t* str, float fontSize,
+void SaveEntryButton::AddPlayTimeHintText(Vm::BufferOffsetContext strAdr,
+                                          float fontSize,
                                           RendererOutlineMode outlineMode,
                                           glm::vec2 relativePosition) {
-  PlayTimeHint = Label(str, glm::vec2(Bounds.X, Bounds.Y) + relativePosition,
+  PlayTimeHint = Label(strAdr, glm::vec2(Bounds.X, Bounds.Y) + relativePosition,
                        fontSize, outlineMode, IsLocked ? 69 : 0);
 }
 
@@ -96,10 +100,11 @@ void SaveEntryButton::AddPlayTimeText(std::string_view str, float fontSize,
                    fontSize, outlineMode, IsLocked ? 69 : 0);
 }
 
-void SaveEntryButton::AddSaveDateHintText(uint8_t* str, float fontSize,
+void SaveEntryButton::AddSaveDateHintText(Vm::BufferOffsetContext strAdr,
+                                          float fontSize,
                                           RendererOutlineMode outlineMode,
                                           glm::vec2 relativePosition) {
-  SaveDateHint = Label(str, glm::vec2(Bounds.X, Bounds.Y) + relativePosition,
+  SaveDateHint = Label(strAdr, glm::vec2(Bounds.X, Bounds.Y) + relativePosition,
                        fontSize, outlineMode, IsLocked ? 69 : 0);
 }
 

--- a/src/ui/widgets/chlcc/saveentrybutton.h
+++ b/src/ui/widgets/chlcc/saveentrybutton.h
@@ -19,25 +19,25 @@ class SaveEntryButton : public Widgets::Button {
   void Render() override;
   int GetPage() const;
   void AddNormalSpriteLabel(Sprite norm, glm::vec2 pos);
-  void AddEntryNumberHintText(uint8_t* str, float fontSize,
+  void AddEntryNumberHintText(Vm::BufferOffsetContext strAdr, float fontSize,
                               RendererOutlineMode outlineMode,
                               glm::vec2 relativePosition);
   void AddEntryNumberText(std::string_view str, float fontSize,
                           RendererOutlineMode outlineMode,
                           glm::vec2 relativePosition);
-  void AddPlayTimeHintText(uint8_t* str, float fontSize,
+  void AddPlayTimeHintText(Vm::BufferOffsetContext strAdr, float fontSize,
                            RendererOutlineMode outlineMode,
                            glm::vec2 relativePosition);
   void AddPlayTimeText(std::string_view str, float fontSize,
                        RendererOutlineMode outlineMode,
                        glm::vec2 relativePosition);
-  void AddSaveDateHintText(uint8_t* str, float fontSize,
+  void AddSaveDateHintText(Vm::BufferOffsetContext strAdr, float fontSize,
                            RendererOutlineMode outlineMode,
                            glm::vec2 relativePosition);
   void AddSaveDateText(std::string_view str, float fontSize,
                        RendererOutlineMode outlineMode,
                        glm::vec2 relativePosition);
-  void AddSceneTitleText(uint8_t* str, float fontSize,
+  void AddSceneTitleText(Vm::BufferOffsetContext strAdr, float fontSize,
                          RendererOutlineMode outlineMode,
                          glm::vec2 relativeTitlePosition,
                          glm::vec2 relativeNoDataPosition);

--- a/src/ui/widgets/chlcc/trackselectbutton.cpp
+++ b/src/ui/widgets/chlcc/trackselectbutton.cpp
@@ -21,12 +21,12 @@ TrackSelectButton::TrackSelectButton(int id, Sprite const &focused,
                  FocusedSprite.Bounds.Height);
 }
 
-void TrackSelectButton::SetTrackText(uint8_t *str) {
-  TrackName = Label(str, TrackTextPos, 20, RendererOutlineMode::None, 0);
+void TrackSelectButton::SetTrackText(Vm::BufferOffsetContext strAdr) {
+  TrackName = Label(strAdr, TrackTextPos, 20, RendererOutlineMode::None, 0);
 }
 
-void TrackSelectButton::SetArtistText(uint8_t *str) {
-  Artist = Label(str, ArtistTextPos, 20, RendererOutlineMode::None, 0);
+void TrackSelectButton::SetArtistText(Vm::BufferOffsetContext strAdr) {
+  Artist = Label(strAdr, ArtistTextPos, 20, RendererOutlineMode::None, 0);
 }
 
 void TrackSelectButton::Render() {

--- a/src/ui/widgets/chlcc/trackselectbutton.h
+++ b/src/ui/widgets/chlcc/trackselectbutton.h
@@ -14,8 +14,8 @@ class TrackSelectButton : public Button {
   TrackSelectButton(int id, Sprite const &focused, glm::vec2 pos,
                     glm::vec2 numOffset, glm::vec2 trackOffset,
                     glm::vec2 artistOffset);
-  void SetTrackText(uint8_t *str);
-  void SetArtistText(uint8_t *str);
+  void SetTrackText(Vm::BufferOffsetContext strAdr);
+  void SetArtistText(Vm::BufferOffsetContext strAdr);
   void Render() override;
   void MoveTracks(glm::vec2 baseline);
 

--- a/src/ui/widgets/label.h
+++ b/src/ui/widgets/label.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <span>
+#include "../../vm/vm.h"
+#include "../../vm/sc3stream.h"
 #include "../widget.h"
 #include "../../text.h"
 #include "../../renderer/renderer.h"
@@ -16,12 +19,16 @@ class Label : public Widget {
         RendererOutlineMode outlineMode);
   Label(std::span<ProcessedTextGlyph> str, float textWidth, float fontSize,
         RendererOutlineMode outlineMode);
-  Label(uint8_t* str, glm::vec2 pos, float fontSize,
+  Label(Vm::BufferOffsetContext scrCtx, glm::vec2 pos, float fontSize,
         RendererOutlineMode outlineMode, int colorIndex = 10);
+  Label(Vm::BufferOffsetContext scrCtx, glm::vec2 pos, float fontSize,
+        RendererOutlineMode outlineMode, DialogueColorPair colorPair);
+  Label(Vm::Sc3Stream& stream, glm::vec2 pos, float fontSize,
+        RendererOutlineMode outlineMode, int colorIndex = 10);
+  Label(Vm::Sc3Stream& stream, glm::vec2 pos, float fontSize,
+        RendererOutlineMode outlineMode, DialogueColorPair colorPair);
   Label(std::string_view str, glm::vec2 pos, float fontSize,
         RendererOutlineMode outlineMode, int colorIndex = 10);
-  Label(uint8_t* str, glm::vec2 pos, float fontSize,
-        RendererOutlineMode outlineMode, DialogueColorPair colorPair);
   Label(std::string_view str, glm::vec2 pos, float fontSize,
         RendererOutlineMode outlineMode, DialogueColorPair colorPair);
 
@@ -36,12 +43,12 @@ class Label : public Widget {
                float fontSize, RendererOutlineMode outlineMode);
   void SetText(std::span<ProcessedTextGlyph> str, float textWidth,
                float fontSize, RendererOutlineMode outlineMode);
-  void SetText(uint8_t* str, float fontSize, RendererOutlineMode outlineMode,
-               int colorIndex = 10);
+  void SetText(Vm::BufferOffsetContext scrCtx, float fontSize,
+               RendererOutlineMode outlineMode, int colorIndex = 10);
+  void SetText(Vm::BufferOffsetContext scrCtx, float fontSize,
+               RendererOutlineMode outlineMode, DialogueColorPair colorPair);
   void SetText(std::string_view str, float fontSize,
                RendererOutlineMode outlineMode, int colorIndex = 10);
-  void SetText(uint8_t* str, float fontSize, RendererOutlineMode outlineMode,
-               DialogueColorPair colorPair);
   void SetText(std::string_view str, float fontSize,
                RendererOutlineMode outlineMode, DialogueColorPair colorPair);
   void ClearText() {
@@ -49,6 +56,10 @@ class Label : public Widget {
     IsText = false;
     Bounds = {};
   }
+  void SetText(Vm::Sc3Stream& stream, float fontSize,
+               RendererOutlineMode outlineMode, int colorIndex = 10);
+  void SetText(Vm::Sc3Stream& stream, float fontSize,
+               RendererOutlineMode outlineMode, DialogueColorPair colorPair);
 
   size_t GetTextLength() { return Text.size(); }
   float GetFontSize() { return FontSize; }

--- a/src/ui/widgets/mo6tw/albumthumbnailbutton.cpp
+++ b/src/ui/widgets/mo6tw/albumthumbnailbutton.cpp
@@ -21,7 +21,6 @@ AlbumThumbnailButton::AlbumThumbnailButton(
                            focusedBottomLeft, focusedBottomRight, pos) {
   TotalVariations = totalVariations;
   UnlockedVariations = unlockedVariations;
-  Vm::Sc3VmThread dummy;
   uint16_t sc3StringBuffer[10];
 
   std::string variationsCount =
@@ -29,11 +28,13 @@ AlbumThumbnailButton::AlbumThumbnailButton(
           ? fmt::format("{:d}/{:d}", unlockedVariations, totalVariations)
           : "\?\?/\?\?";
   TextGetSc3String(variationsCount, sc3StringBuffer);
-  dummy.Ip = (uint8_t*)sc3StringBuffer;
-  InfoTextWidth = TextGetPlainLineWidth(&dummy, Profile::Dialogue::DialogueFont,
+  Vm::Sc3Stream stream(sc3StringBuffer);
+
+  InfoTextWidth = TextGetPlainLineWidth(stream, Profile::Dialogue::DialogueFont,
                                         ThumbnailButtonTextFontSize);
+  stream = Vm::Sc3Stream(sc3StringBuffer);
   InfoText = new Label(
-      (uint8_t*)sc3StringBuffer,
+      stream,
       pos +
           glm::vec2(norm.Bounds.Width - InfoTextWidth,
                     norm.Bounds.Height - ThumbnailButtonTextFontSize) +

--- a/src/ui/widgets/mo6tw/saveentrybutton.cpp
+++ b/src/ui/widgets/mo6tw/saveentrybutton.cpp
@@ -39,10 +39,10 @@ void SaveEntryButton::Render() {
                        Tint);
 }
 
-void SaveEntryButton::AddSceneTitleText(uint8_t* str, float fontSize,
-                                        bool outline) {
-  Impacto::Vm::Sc3VmThread dummy;
-  dummy.Ip = str;
+void SaveEntryButton::AddSceneTitleText(Vm::BufferOffsetContext strAdr,
+                                        float fontSize, bool outline) {
+  Vm::Sc3VmThread dummy;
+  dummy.SetIp(strAdr);
   if (EntryActive) {
     SceneTitle = TextLayoutPlainLine(
         &dummy, 255, Profile::Dialogue::DialogueFont, fontSize,
@@ -56,40 +56,40 @@ void SaveEntryButton::AddSceneTitleText(uint8_t* str, float fontSize,
   }
 }
 
-void SaveEntryButton::AddPlayTimeHintText(uint8_t* str, float fontSize,
-                                          bool outline) {
-  Impacto::Vm::Sc3VmThread dummy;
-  dummy.Ip = str;
+void SaveEntryButton::AddPlayTimeHintText(Vm::BufferOffsetContext strAdr,
+                                          float fontSize, bool outline) {
+  Vm::Sc3VmThread dummy;
+  dummy.SetIp(strAdr);
   PlayTimeHint = TextLayoutPlainLine(
       &dummy, 255, Profile::Dialogue::DialogueFont, fontSize,
       Profile::Dialogue::ColorTable[0], 1.0f,
       glm::vec2(Bounds.X + 238.0f, Bounds.Y + 45.0f), TextAlignment::Left);
 }
 
-void SaveEntryButton::AddPlayTimeText(uint8_t* str, float fontSize,
-                                      bool outline) {
-  Impacto::Vm::Sc3VmThread dummy;
-  dummy.Ip = str;
+void SaveEntryButton::AddPlayTimeText(Vm::BufferOffsetContext strAdr,
+                                      float fontSize, bool outline) {
+  Vm::Sc3VmThread dummy;
+  dummy.SetIp(strAdr);
   PlayTime = TextLayoutPlainLine(
       &dummy, 255, Profile::Dialogue::DialogueFont, fontSize,
       Profile::Dialogue::ColorTable[0], 1.0f,
       glm::vec2(Bounds.X + 372.0f, Bounds.Y + 61.0f), TextAlignment::Left);
 }
 
-void SaveEntryButton::AddSaveDateHintText(uint8_t* str, float fontSize,
-                                          bool outline) {
-  Impacto::Vm::Sc3VmThread dummy;
-  dummy.Ip = str;
+void SaveEntryButton::AddSaveDateHintText(Vm::BufferOffsetContext strAdr,
+                                          float fontSize, bool outline) {
+  Vm::Sc3VmThread dummy;
+  dummy.SetIp(strAdr);
   SaveDateHint = TextLayoutPlainLine(
       &dummy, 255, Profile::Dialogue::DialogueFont, fontSize,
       Profile::Dialogue::ColorTable[0], 1.0f,
       glm::vec2(Bounds.X + 238.0f, Bounds.Y + 75.0f), TextAlignment::Left);
 }
 
-void SaveEntryButton::AddSaveDateText(uint8_t* str, float fontSize,
-                                      bool outline) {
-  Impacto::Vm::Sc3VmThread dummy;
-  dummy.Ip = str;
+void SaveEntryButton::AddSaveDateText(Vm::BufferOffsetContext strAdr,
+                                      float fontSize, bool outline) {
+  Vm::Sc3VmThread dummy;
+  dummy.SetIp(strAdr);
   SaveDate = TextLayoutPlainLine(
       &dummy, 255, Profile::Dialogue::DialogueFont, fontSize,
       Profile::Dialogue::ColorTable[0], 1.0f,

--- a/src/ui/widgets/mo6tw/saveentrybutton.h
+++ b/src/ui/widgets/mo6tw/saveentrybutton.h
@@ -13,11 +13,16 @@ class SaveEntryButton : public Widgets::Button {
                   Sprite const& highlight, glm::vec2 pos)
       : Widgets::Button(id, norm, focused, highlight, pos) {}
   void Render() override;
-  void AddPlayTimeHintText(uint8_t* str, float fontSize, bool outline);
-  void AddPlayTimeText(uint8_t* str, float fontSize, bool outline);
-  void AddSaveDateHintText(uint8_t* str, float fontSize, bool outline);
-  void AddSaveDateText(uint8_t* str, float fontSize, bool outline);
-  void AddSceneTitleText(uint8_t* str, float fontSize, bool outline);
+  void AddPlayTimeHintText(Vm::BufferOffsetContext strAdr, float fontSize,
+                           bool outline);
+  void AddPlayTimeText(Vm::BufferOffsetContext strAdr, float fontSize,
+                       bool outline);
+  void AddSaveDateHintText(Vm::BufferOffsetContext strAdr, float fontSize,
+                           bool outline);
+  void AddSaveDateText(Vm::BufferOffsetContext strAdr, float fontSize,
+                       bool outline);
+  void AddSceneTitleText(Vm::BufferOffsetContext strAdr, float fontSize,
+                         bool outline);
 
   Sprite Thumbnail;
 

--- a/src/ui/widgets/mo6tw/tipsentrybutton.cpp
+++ b/src/ui/widgets/mo6tw/tipsentrybutton.cpp
@@ -29,7 +29,8 @@ TipsEntryButton::TipsEntryButton(int id, TipsDataRecord* tipRecord,
                         Profile::Dialogue::ColorTable[DefaultColorIndex], 1.0f,
                         glm::vec2(Bounds.X, Bounds.Y), TextAlignment::Left);
   Vm::Sc3VmThread dummy;
-  dummy.Ip = tipRecord->StringPtrs[0];
+  dummy.IpOffset = tipRecord->StringAdr[0];
+  dummy.ScriptBufferId = TipsSystem::GetTipsScriptBufferId();
   Text = TextLayoutPlainLine(
       &dummy, 255, Profile::Dialogue::DialogueFont, TipListEntryFontSize,
       Profile::Dialogue::ColorTable[DefaultColorIndex], 1.0f,
@@ -40,8 +41,10 @@ TipsEntryButton::TipsEntryButton(int id, TipsDataRecord* tipRecord,
                         Profile::Dialogue::ColorTable[DefaultColorIndex], 1.0f,
                         glm::vec2(Bounds.X + TipListEntryNewOffset, Bounds.Y),
                         TextAlignment::Left);
-  dummy.Ip = Vm::ScriptGetTextTableStrAddress(TipListEntryLockedTable,
-                                              TipListEntryLockedIndex);
+  auto lockedScrPos = Vm::ScriptGetTextTableStrAddress(TipListEntryLockedTable,
+                                                       TipListEntryLockedIndex);
+  dummy.IpOffset = lockedScrPos.IpOffset;
+  dummy.ScriptBufferId = lockedScrPos.ScriptBufferId;
   TextLayoutPlainLine(&dummy, 3, TipLockedText, Profile::Dialogue::DialogueFont,
                       TipListEntryFontSize,
                       Profile::Dialogue::ColorTable[UnreadColorIndex], 1.0f,

--- a/src/ui/widgets/toggle.cpp
+++ b/src/ui/widgets/toggle.cpp
@@ -24,11 +24,11 @@ Toggle::Toggle(int id, bool* value, Sprite const& enabled,
 
 Toggle::Toggle(int id, bool* value, Sprite const& enabled,
                Sprite const& disabled, Sprite const& highlight, glm::vec2 pos,
-               bool isCheckbox, uint8_t* str, glm::vec2 labelOfs,
+               bool isCheckbox, Vm::Sc3Stream& stream, glm::vec2 labelOfs,
                float fontSize, RendererOutlineMode outlineMode)
     : Toggle(id, value, enabled, disabled, highlight, pos, isCheckbox) {
   HasTextLabel = true;
-  SetText(str, fontSize, outlineMode);
+  SetText(stream, fontSize, outlineMode);
 }
 
 Toggle::Toggle(int id, bool* value, Sprite const& enabled,
@@ -84,11 +84,9 @@ void Toggle::Render() {
   }
 }
 
-void Toggle::SetText(uint8_t* str, float fontSize,
+void Toggle::SetText(Vm::Sc3Stream& stream, float fontSize,
                      RendererOutlineMode outlineMode) {
-  Impacto::Vm::Sc3VmThread dummy;
-  dummy.Ip = str;
-  Label = TextLayoutPlainLine(&dummy, 255, Profile::Dialogue::DialogueFont,
+  Label = TextLayoutPlainLine(stream, 255, Profile::Dialogue::DialogueFont,
                               fontSize, Profile::Dialogue::ColorTable[10], 1.0f,
                               glm::vec2(Bounds.X, Bounds.Y) + LabelOffset,
                               TextAlignment::Left);

--- a/src/ui/widgets/toggle.h
+++ b/src/ui/widgets/toggle.h
@@ -15,8 +15,9 @@ class Toggle : public Widget {
   Toggle(int id, bool* value, Sprite const& enabled, Sprite const& disabled,
          Sprite const& highlight, glm::vec2 pos, bool isCheckbox);
   Toggle(int id, bool* value, Sprite const& enabled, Sprite const& disabled,
-         Sprite const& highlight, glm::vec2 pos, bool isCheckbox, uint8_t* str,
-         glm::vec2 labelOfs, float fontSize, RendererOutlineMode outlineMode);
+         Sprite const& highlight, glm::vec2 pos, bool isCheckbox,
+         Vm::Sc3Stream& stream, glm::vec2 labelOfs, float fontSize,
+         RendererOutlineMode outlineMode);
   Toggle(int id, bool* value, Sprite const& enabled, Sprite const& disabled,
          Sprite const& highlight, glm::vec2 pos, bool isCheckbox,
          Sprite const& label, glm::vec2 labelOfs);
@@ -30,7 +31,8 @@ class Toggle : public Widget {
   std::function<void(Toggle*)> OnClickHandler;
 
  private:
-  void SetText(uint8_t* str, float fontSize, RendererOutlineMode outlineMode);
+  void SetText(Vm::Sc3Stream& stream, float fontSize,
+               RendererOutlineMode outlineMode);
 
   Sprite EnabledSprite;
   Sprite DisabledSprite;

--- a/src/vm/expression.h
+++ b/src/vm/expression.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "vm.h"
+#include "sc3stream.h"
 
 namespace Impacto {
 

--- a/src/vm/inst_gamespecific.cpp
+++ b/src/vm/inst_gamespecific.cpp
@@ -559,7 +559,7 @@ VmInstruction(InstMapSystem) {
           arg3 != ScrWork[6362]) {
         Impacto::UI::MapSystem::MapZoomInit(arg1, arg2, arg3);
       } else {
-        thread->Ip += 3;
+        thread->IpOffset += 3;
       }
     } break;
     case 0x17:
@@ -582,7 +582,7 @@ VmInstruction(InstMapSystem) {
           arg3 != ScrWork[6362]) {
         Impacto::UI::MapSystem::MapZoomInit2(arg1, arg2);
       } else {
-        thread->Ip += 3;
+        thread->IpOffset += 3;
       }
     } break;
     case 0x19:
@@ -598,10 +598,10 @@ VmInstruction(InstMapSystem) {
       if (arg1 != ScrWork[6363] || arg2 != ScrWork[6364] ||
           arg3 != ScrWork[6362]) {
         if (!Impacto::UI::MapSystem::MapZoomInit3(arg1, arg2, arg3)) {
-          thread->Ip += 3;
+          thread->IpOffset += 3;
         }
       } else {
-        thread->Ip += 3;
+        thread->IpOffset += 3;
       }
     } break;
     case 0x1B: {
@@ -611,10 +611,10 @@ VmInstruction(InstMapSystem) {
       if (arg1 != ScrWork[6363] || arg2 != ScrWork[6364] ||
           arg3 != ScrWork[6362]) {
         if (!Impacto::UI::MapSystem::MapMoveAnimeInit2(arg1, arg2, arg3)) {
-          thread->Ip += 3;
+          thread->IpOffset += 3;
         }
       } else {
-        thread->Ip += 3;
+        thread->IpOffset += 3;
       }
     } break;
     case 0x1C:
@@ -1075,7 +1075,7 @@ VmInstruction(InstYesNoTriggerCCLCC) {
         ResetInstruction;
         BlockThread;
       } else if (YesNoTrigger::YesNoTriggerPtr->State != YesNoState::Complete) {
-        thread->Ip = branchAddress;
+        thread->IpOffset = branchAddress;
         BlockThread;
       }
 

--- a/src/vm/inst_graphics3d.cpp
+++ b/src/vm/inst_graphics3d.cpp
@@ -132,12 +132,12 @@ VmInstruction(InstCHAUnk02073D_Dash) {
     ImpLogSlow(
         LogLevel::Warning, LogChannel::VMStub,
         "STUB instruction CHAUnk02073D_Dash(arg1: {:d}, arg2: {:d}, arg3: "
-        "{:d}, arg4: {:d}, arg5: {:p})\n",
-        arg1, arg2, arg3, arg4, (void*)arg5);
+        "{:d}, arg4: {:d}, arg5: {:d})\n",
+        arg1, arg2, arg3, arg4, arg5);
   } else {
     PopLocalLabel(arg3);
-    uint16_t* dataArray = (uint16_t*)arg3;
-    uint16_t testNum = dataArray[1];
+    auto dataIp = arg3;
+    uint16_t testNum = ScriptBuffers[thread->ScriptBufferId][dataIp + 1];
     if (Renderer->Scene->Renderables[arg2]->Status == LoadStatus::Loaded &&
         testNum != 0) {
       // TODO shouldn't this wait for that renderable to be loaded?

--- a/src/vm/inst_macros.inc
+++ b/src/vm/inst_macros.inc
@@ -1,55 +1,52 @@
 #define StartInstruction                                     \
-  uint8_t* _oldIp = thread->Ip;                              \
-  bool noExpressions = (bool)(*thread->Ip & 0x80);           \
+  uint8_t* _oldIp = thread->GetIp();                         \
+  bool noExpressions = (bool)(*thread->GetIp() & 0x80);      \
   /* Sometimes needed by subsequent code, silence warning */ \
   (void)noExpressions;                                       \
   (void)_oldIp;                                              \
-  thread->Ip += 2
-#define ResetInstruction thread->Ip = _oldIp
+  thread->IpOffset += 2
+#define ResetInstruction thread->SetIp(_oldIp)
 
 #define BlockThread BlockCurrentScriptThread = true
 
-#define PopUint8(name)                                                    \
-  uint8_t name = *thread->Ip;                                             \
-  /* Sometimes needed by subsequent code, silence warning */              \
-  (void)name;                                                             \
-  thread->Ip++
+#define PopUint8(name)                                       \
+  uint8_t name = *thread->GetIp();                           \
+  /* Sometimes needed by subsequent code, silence warning */ \
+  (void)name;                                                \
+  thread->IpOffset += 1;
 #define PopUint16(name)                                                   \
-  uint16_t name = SDL_SwapLE16(UnalignedRead<uint16_t>(thread->Ip));      \
+  uint16_t name = SDL_SwapLE16(UnalignedRead<uint16_t>(thread->GetIp())); \
   /* Sometimes needed by subsequent code, silence warning */              \
   (void)name;                                                             \
-  thread->Ip += 2
-#define PopLocalLabel(name)                                             \
-  uint8_t* name;                                                        \
-  {                                                                     \
-    PopUint16(labelNum);                                                \
-    name = ScriptGetLabelAddress(ScriptBuffers[thread->ScriptBufferId], \
-                                 labelNum);                             \
-  }                                                                     \
+  thread->IpOffset += 2;
+#define PopLocalLabel(name)                                         \
+  uint32_t name;                                                    \
+  {                                                                 \
+    PopUint16(labelNum);                                            \
+    name = ScriptGetLabelAddress(thread->ScriptBufferId, labelNum); \
+  }                                                                 \
   (void)0
-#define PopFarLabel(name, scriptBufferId)                                  \
-  uint8_t* name;                                                           \
-  {                                                                        \
-    PopUint16(labelNum);                                                   \
-    name = ScriptGetLabelAddress(ScriptBuffers[scriptBufferId], labelNum); \
-  }                                                                        \
+#define PopFarLabel(name, scriptBufferId)                   \
+  uint32_t name;                                            \
+  {                                                         \
+    PopUint16(labelNum);                                    \
+    name = ScriptGetLabelAddress(scriptBufferId, labelNum); \
+  }                                                         \
   (void)0
 #define PopExpression(name) \
   int name;                 \
   ExpressionEval(thread, &name)
-#define PopString(name)                                                        \
-  uint8_t* name;                                                               \
-  {                                                                            \
-    PopUint16(stringNum);                                                      \
-    name =                                                                     \
-        ScriptGetStrAddress(ScriptBuffers[thread->ScriptBufferId], stringNum); \
-  }                                                                            \
+#define PopString(name)                                            \
+  uint32_t name;                                                   \
+  {                                                                \
+    PopUint16(stringNum);                                          \
+    name = ScriptGetStrAddress(thread->ScriptBufferId, stringNum); \
+  }                                                                \
   (void)0
-#define PopMsbString(name)                                                     \
-  uint8_t* name;                                                               \
-  {                                                                            \
-    PopExpression(stringNum);                                                  \
-    name =                                                                     \
-        MsbGetStrAddress(MsbBuffers[thread->ScriptBufferId], stringNum);       \
-  }                                                                            \
+#define PopMsbString(name)                                      \
+  uint32_t name;                                                \
+  {                                                             \
+    PopExpression(stringNum);                                   \
+    name = MsbGetStrAddress(thread->ScriptBufferId, stringNum); \
+  }                                                             \
   (void)0

--- a/src/vm/inst_misc.cpp
+++ b/src/vm/inst_misc.cpp
@@ -183,7 +183,7 @@ VmInstruction(InstPressStartNew) {
   PopUint8(type);
   if (type == 0 || type == 3) {
     PopLocalLabel(labelAdr);
-    thread->Ip = labelAdr;
+    thread->IpOffset = labelAdr;
   }
 }
 VmInstruction(InstClearFlagChk) {

--- a/src/vm/sc3stream.h
+++ b/src/vm/sc3stream.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <cstdint>
+#include <span>
+#include "thread.h"
+
+namespace Impacto {
+namespace Vm {
+
+class Sc3Stream {
+ public:
+  Sc3Stream(uint16_t* ptr) : Ptr(reinterpret_cast<uint8_t*>(ptr)) {}
+  Sc3Stream(uint8_t* ptr) : Ptr(ptr) {}
+  uint8_t ReadU8() {
+    uint8_t result = PeekU8();
+    Advance(1);
+    return result;
+  }
+
+  uint16_t ReadU16() {
+    uint16_t result = PeekU16();
+    Advance(2);
+    return result;
+  }
+  uint16_t PeekU16(int64_t offset = 0) const {
+    auto adjOffset = offset * sizeof(uint16_t);
+    return (PeekU8(adjOffset + 1) << 8) | PeekU8(adjOffset);
+  }
+  uint8_t PeekU8(int64_t offset = 0) const { return *(Ptr + offset); };
+  uint8_t* Data() const { return Ptr; }
+  void Advance(int64_t n) { Ptr += n; }
+
+ private:
+  uint8_t* Ptr{};
+};
+}  // namespace Vm
+}  // namespace Impacto

--- a/src/vm/thread.cpp
+++ b/src/vm/thread.cpp
@@ -1,4 +1,5 @@
 #include "thread.h"
+#include "vm.h"
 
 namespace Impacto {
 namespace Vm {
@@ -16,7 +17,7 @@ void* Sc3VmThread::GetMemberPointer(uint32_t offset) {
     case TO_ScrParam:
       return &ScriptParam;
     case TO_ScrAddr:
-      return &Ip;
+      return &IpOffset;
     case TO_LoopCount:
       return &LoopCounter;
     case TO_LoopAddr:
@@ -42,5 +43,21 @@ void* Sc3VmThread::GetMemberPointer(uint32_t offset) {
       break;
   }
 }
+
+uint8_t* Sc3VmThread::GetIp() const {
+  return ScriptBuffers[ScriptBufferId].data() + IpOffset;
+}
+void Sc3VmThread::SetIp(uint8_t* ptr) {
+  assert(ptr >= ScriptBuffers[ScriptBufferId].data() &&
+         ptr < ScriptBuffers[ScriptBufferId].data() +
+                   ScriptBuffers[ScriptBufferId].size());
+  IpOffset = static_cast<uint32_t>(ptr - ScriptBuffers[ScriptBufferId].data());
+}
+
+void Sc3VmThread::SetIp(BufferOffsetContext ctx) {
+  IpOffset = ctx.IpOffset;
+  ScriptBufferId = ctx.ScriptBufferId;
+}
+
 }  // namespace Vm
 }  // namespace Impacto

--- a/src/vm/thread.h
+++ b/src/vm/thread.h
@@ -46,6 +46,11 @@ enum ThreadMemberOffset {
   TO_ThdVarBegin = 47
 };
 
+struct BufferOffsetContext {
+  uint32_t ScriptBufferId;
+  uint32_t IpOffset;
+};
+
 class Vm;
 
 struct Sc3VmThread {
@@ -59,12 +64,12 @@ struct Sc3VmThread {
   uint32_t GroupId;
   uint32_t WaitCounter;
   uint32_t ScriptParam;
-  uint8_t* Ip;
+  uint32_t IpOffset;
   uint32_t LoopCounter;
   uint16_t LoopLabelNum;
   uint32_t CallStackDepth;
   union {
-    uint8_t* ReturnAddresses[MaxCallStackDepth];
+    uint32_t ReturnAddresses[MaxCallStackDepth];
     uint16_t ReturnIds[MaxCallStackDepth];
   };
   uint32_t ReturnScriptBufferIds[MaxCallStackDepth];
@@ -77,6 +82,9 @@ struct Sc3VmThread {
   uint32_t DialoguePageId;
 
   void* GetMemberPointer(uint32_t offset);
+  uint8_t* GetIp() const;
+  void SetIp(uint8_t* ptr);
+  void SetIp(BufferOffsetContext ctx);
 };
 
 }  // namespace Vm

--- a/src/vm/vm.h
+++ b/src/vm/vm.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <span>
 #include "thread.h"
 #include "../io/vfs.h"
 #include <enum.h>
@@ -18,13 +19,14 @@ int constexpr MaxLoadedScripts = 16;
 int constexpr MaxThreads = 100;
 int constexpr MaxThreadGroups = 12;
 
-uint32_t ScriptGetLabelSize(uint8_t* scriptBufferAdr, uint32_t labelNum);
-uint8_t* ScriptGetLabelAddress(uint8_t* scriptBufferAdr, uint32_t labelNum);
-uint32_t ScriptGetLabelAddressNum(uint8_t* scriptBufferAdr, uint32_t labelNum);
-uint8_t* ScriptGetStrAddress(uint8_t* scriptBufferAdr, uint32_t strNum);
-uint8_t* ScriptGetTextTableStrAddress(uint32_t textTableId, uint32_t strNum);
-uint8_t* ScriptGetRetAddress(uint8_t* scriptBufferAdr, uint32_t retNum);
-uint8_t* MsbGetStrAddress(uint8_t* msbBufferAdr, uint32_t mesNum);
+uint32_t ScriptGetLabelSize(uint32_t scriptBufferId, uint32_t labelNum);
+uint32_t ScriptGetLabelAddress(uint32_t scriptBufferId, uint32_t labelNum);
+uint32_t ScriptGetStrAddress(uint32_t scriptBufferId, uint32_t strNum);
+
+BufferOffsetContext ScriptGetTextTableStrAddress(uint32_t textTableId,
+                                                 uint32_t strNum);
+uint32_t ScriptGetRetAddress(uint32_t scriptBufferId, uint32_t retNum);
+uint32_t MsbGetStrAddress(uint32_t scriptBufferId, uint32_t mesNum);
 
 void Init();
 void Update(float dt);
@@ -37,8 +39,8 @@ void ControlThreadGroup(ThreadGroupControlType controlType, uint32_t groupId);
 void DestroyThread(Sc3VmThread* thread);
 void RunThread(Sc3VmThread* thread);
 
-inline uint8_t* ScriptBuffers[MaxLoadedScripts];
-inline uint8_t* MsbBuffers[MaxLoadedScripts];
+inline std::span<uint8_t> ScriptBuffers[MaxLoadedScripts];
+inline std::span<uint8_t> MsbBuffers[MaxLoadedScripts];
 
 inline Io::FileMeta LoadedScriptMetas[MaxLoadedScripts];
 
@@ -49,8 +51,8 @@ inline bool BlockCurrentScriptThread;
 inline uint32_t SwitchValue;  // Used in InstSwitch and InstCase
 
 struct TextTableEntry {
-  uint8_t* scriptBufferAdr;
-  uint8_t* labelAdr;
+  uint8_t scriptBufferId;
+  uint32_t labelAdr;
 };
 
 inline TextTableEntry TextTable[16];

--- a/src/voicetable.cpp
+++ b/src/voicetable.cpp
@@ -17,7 +17,7 @@ bool VoiceTable::LoadSync(uint32_t id) {
     VoiceMeta voiceMeta{dataIndex, voiceLengthSecTimes6};
     TableOfContents[i] = voiceMeta;
   }
-  const size_t endToc = 4 * VoiceFileCount + 4;
+  [[maybe_unused]] const size_t endToc = 4 * VoiceFileCount + 4;
   assert((size_t)stream->Position == endToc);
   LipSyncData.resize(stream->Meta.Size - stream->Position);
   stream->Read(LipSyncData.data(), LipSyncData.size());


### PR DESCRIPTION
Changes VM threads to use IP as an offset to a script buffer instead of a pointer.

Text changes to parse sc3 text from script buffers, from a generated or string token only string, to avoid passing a sc3buffer pointer directly?

Load IPs correctly without relying on script load hacks for chlcc/mo6tw