### PR TITLE
Added partial scroll functionality to CHLCC music menu

### DIFF
--- a/profiles/chlcc/game.lua
+++ b/profiles/chlcc/game.lua
@@ -1,7 +1,7 @@
 root.ActiveRenderer = RendererType.OpenGL;
 
 root.LayerCount = 100;
-root.GameFeatures = GameFeature.Sc3VirtualMachine | GameFeature.Renderer2D | GameFeature.Input | GameFeature.Audio | GameFeature.Video;
+root.GameFeatures = GameFeature.Sc3VirtualMachine | GameFeature.Renderer2D | GameFeature.Input | GameFeature.Audio | GameFeature.Video | GameFeature.DebugMenu;
 root.DesignWidth = 1280;
 root.DesignHeight = 720;
 

--- a/profiles/chlcc/hud/extramenus.lua
+++ b/profiles/chlcc/hud/extramenus.lua
@@ -209,6 +209,8 @@ root.ExtraMenus = {
         TrackOffset = { X = 0, Y = 27 },
         TrackHighlight = "TrackHighlight",
         TrackNumRelativePos = { X = 25, Y = 5 },
+        ButtonPromptPosition = { X = 738, Y = 651 },
+        ButtonPromptSprite = "MusicButtonPrompt",
         PlaymodeRepeatPos = { X = 718, Y = 146 },
         PlaymodeAllPos = { X = 771, Y = 146 },
         PlaymodeRepeat = "PlaymodeRepeat",
@@ -555,6 +557,12 @@ root.Sprites["NowPlaying"] = {
     Sheet = "Sound",
     Bounds = { X = 1, Y = 611, Width = 656, Height = 19 }
 }
+
+root.Sprites["MusicButtonPrompt"] = {
+    Sheet = "Sound",
+    Bounds = { X = 1, Y = 724, Width = 552, Height = 28}
+}
+
 
 root.Sprites["SoundLibraryTitle"] = {
     Sheet = "Sound",

--- a/profiles/chlcc/hud/extramenus.lua
+++ b/profiles/chlcc/hud/extramenus.lua
@@ -206,7 +206,7 @@ root.ExtraMenus = {
         TrackButtonPosTemplate = { X = 94, Y = 170 },
         TrackNameOffset = { X = 95, Y = 5 },
         ArtistOffset = { X = 411, Y = 5 },
-        TrackOffset = { X = 0, Y = 28 },
+        TrackOffset = { X = 0, Y = 27 },
         TrackHighlight = "TrackHighlight",
         TrackNumRelativePos = { X = 25, Y = 5 },
         PlaymodeRepeatPos = { X = 718, Y = 146 },
@@ -245,6 +245,8 @@ root.ExtraMenus = {
             { X = 220, Y = 51 },
             { X = 234, Y = 52 },
         },
+        MusicDirectionalHoldTime = 0.2,
+        MusicDirectionalFocusTimeInterval = 0.05,
     }
 }
 

--- a/profiles/chlcc/scriptinput.lua
+++ b/profiles/chlcc/scriptinput.lua
@@ -1,16 +1,16 @@
---[[root.Input = {
+root.Input = {
   -- Keyboard
   KB_PAD1A={40},             -- Return
   KB_PAD1B={42},             -- Backspace
-  KB_PAD1X={60},             -- F3
-  KB_PAD1Y={59},             -- F2
-  KB_PAD1SELECT={61},        -- F4
-  KB_PAD1START={30},         -- 1
+  KB_PAD1X={30},             -- 1 (Menu)
+  KB_PAD1Y={59},             -- F2 (Backlog)
+  KB_PAD1SELECT={61},        -- F4 (Auto)
+  KB_PAD1START={60},         -- F3 (Skip)
   KB_PAD1UP={82},            -- Up
   KB_PAD1DOWN={81},          -- Down
   KB_PAD1LEFT={80},          -- Left
   KB_PAD1RIGHT={79},         -- Right
-  KB_PAD1L1={20, 224},     -- Q, LCTRL
+  KB_PAD1L1={20, 224},     -- Q, LCTRL (Tips Menu)
   KB_PAD1L2={29},            -- Z
   KB_PAD1L3={32},            -- 3
   KB_PAD1R1={8},             -- E
@@ -89,4 +89,4 @@ root.PADcustomA = {
   root.PADinput.PAD1DOWN_RS,
   root.PADinput.PAD1LEFT_RS,
   root.PADinput.PAD1RIGHT_RS,
-}]]
+}

--- a/profiles/chlcc/vfs.lua
+++ b/profiles/chlcc/vfs.lua
@@ -1,6 +1,7 @@
 root.Vfs = {
     Mounts = {
         ["script"] = {"games/chlcc/gamedata/script.cpk"},
+        ["scriptdbg"] = {"games/chlcc/gamedata/scriptdbg.cls"},
         ["system"] = {"games/chlcc/gamedata/system.cpk"},
         ["bgm"] = {"games/chlcc/gamedata/bgm.cpk"},
         ["se"] = {"games/chlcc/gamedata/se.cpk"},

--- a/src/games/chlcc/musicmenu.cpp
+++ b/src/games/chlcc/musicmenu.cpp
@@ -184,6 +184,7 @@ void MusicMenu::Render() {
                       MainItems->Children[CurrentlyPlayingTrackId]->Bounds.Y) +
                 HighlightStarRelativePos);
       }
+      DrawButtonPrompt();
     }
   }
 }
@@ -397,6 +398,16 @@ inline void MusicMenu::DrawRedBar() {
     RedBarSprite.Bounds.Width = pixelPerAdvanceRight;
     RedBarPosition = RightRedBarPosition;
     Renderer->DrawSprite(RedBarSprite, RedBarPosition);
+  }
+}
+
+inline void MusicMenu::DrawButtonPrompt() {
+  if (MenuTransition.IsIn()) {
+    Renderer->DrawSprite(ButtonPromptSprite, ButtonPromptPosition);
+  } else if (MenuTransition.Progress > 0.734f) {
+    float x = ButtonPromptPosition.x - 2560.0f * (MenuTransition.Progress - 1);
+    Renderer->DrawSprite(ButtonPromptSprite,
+                         glm::vec2(x, ButtonPromptPosition.y));
   }
 }
 

--- a/src/games/chlcc/musicmenu.h
+++ b/src/games/chlcc/musicmenu.h
@@ -36,6 +36,7 @@ class MusicMenu : public Menu {
   void DrawCircles();
   void DrawErin();
   void DrawRedBar();
+  void DrawButtonPrompt();
 
   void UpdateEntries();
   void UpdateTitles();

--- a/src/games/chlcc/musicmenu.h
+++ b/src/games/chlcc/musicmenu.h
@@ -1,9 +1,11 @@
 #pragma once
 
 #include "../../ui/menu.h"
+#include "../../ui/turboonholdhandler.h"
 #include "../../ui/widgets/group.h"
 #include "../../ui/widgets/button.h"
 #include "../../ui/widgets/label.h"
+
 
 namespace Impacto {
 namespace UI {
@@ -22,7 +24,7 @@ class MusicMenu : public Menu {
 
   void Show();
   void Hide();
-  void UpdateInput();
+  void UpdateInput(float dt);
   void Update(float dt);
   void Render();
 
@@ -60,6 +62,10 @@ class MusicMenu : public Menu {
   glm::vec2 RedTitleLabelPos;
   glm::vec2 RightTitlePos;
   glm::vec2 LeftTitlePos;
+  
+  std::optional<FocusDirection> QueuedMove;
+  TurboOnHoldHandler DirectionButtonHoldHandler;
+  bool TurboMoved = false;
 };
 
 }  // namespace CHLCC

--- a/src/profile/games/chlcc/musicmenu.cpp
+++ b/src/profile/games/chlcc/musicmenu.cpp
@@ -35,6 +35,8 @@ void Configure() {
   TrackOffset = EnsureGetMember<glm::vec2>("TrackOffset");
   TrackHighlight = EnsureGetMember<Sprite>("TrackHighlight");
   TrackNumRelativePos = EnsureGetMember<glm::vec2>("TrackNumRelativePos");
+  ButtonPromptPosition = EnsureGetMember<glm::vec2>("ButtonPromptPosition");
+  ButtonPromptSprite = EnsureGetMember<Sprite>("ButtonPromptSprite");
   PlaymodeRepeatPos = EnsureGetMember<glm::vec2>("PlaymodeRepeatPos");
   PlaymodeAllPos = EnsureGetMember<glm::vec2>("PlaymodeAllPos");
   PlaymodeRepeat = EnsureGetMember<Sprite>("PlaymodeRepeat");

--- a/src/profile/games/chlcc/musicmenu.h
+++ b/src/profile/games/chlcc/musicmenu.h
@@ -43,6 +43,8 @@ inline Sprite PlaymodeRepeat;
 inline Sprite PlaymodeAll;
 inline Sprite PlaymodeRepeatHighlight;
 inline Sprite PlaymodeAllHighlight;
+inline float MusicDirectionalHoldTime;
+inline float MusicDirectionalFocusTimeInterval;
 inline Sprite NowPlaying;
 inline glm::vec2 NowPlayingPos;
 inline float NowPlayingAnimationDuration;

--- a/src/profile/games/chlcc/musicmenu.h
+++ b/src/profile/games/chlcc/musicmenu.h
@@ -59,6 +59,8 @@ inline glm::vec2 HighlightStarRelativePos;
 inline int Playlist[MusicTrackCount];
 inline Sprite SelectSound[11];
 inline glm::vec2 SelectSoundPos[11];
+inline glm::vec2 ButtonPromptPosition;
+inline Sprite ButtonPromptSprite;
 
 void Configure();
 


### PR DESCRIPTION
Added scrolling in the music menu, but scrolling more than one line at a time causes minor issues. Additionally, scrolling is infinite, and "loops" around to the top index once the bottom is reached. Finally, the menu opening twice bug is still present. 