### PR TITLE
[C;CLCC] Fix blinking on PressToStart

### DIFF
--- a/src/games/cclcc/titlemenu.cpp
+++ b/src/games/cclcc/titlemenu.cpp
@@ -534,7 +534,11 @@ void TitleMenu::Render() {
                       1.0f - ScrWork[SW_TITLEDISPCT] / 60.0f));
       } break;
       case 2: {  // Transition between Press to start and menus
-        DrawMainMenuBackGraphics();
+        if (IsExploding) {
+          DrawMainMenuBackGraphics();
+        } else {
+          DrawDISwordBackground();
+        }
         DrawStartButton();
         TitleAnimationSprite.Render(-1);
         DrawSmoke(SmokeOpacityNormal);


### PR DESCRIPTION
Fixes issue https://github.com/CommitteeOfZero/impacto/issues/135

DrawDISwordBackground until animation starts, then DrawMainMenuBackGraphics after animation starts

<h2>Dev Proof<h2/>

Before 

https://github.com/user-attachments/assets/330252a5-6f6a-4d02-bed6-f56fd94ee115


After

https://github.com/user-attachments/assets/ae3d61ba-6bf0-40a6-8800-5b492f2f52d5

