### PR TITLE
Widget move fixes

### DIFF
--- a/src/games/cclcc/musicmenu.h
+++ b/src/games/cclcc/musicmenu.h
@@ -11,12 +11,11 @@ namespace UI {
 namespace CCLCC {
 
 struct MusicBGs : public UI::Widget {
-  using UI::Widget::Move;
-  using UI::Widget::MoveTo;
   void UpdateInput(float dt) override {};
-  void Move(glm::vec2 relativePos) override;
-  void MoveTo(glm::vec2 pos) override { Move(pos - Bounds.GetPos()); }
   void Render() override;
+
+  using Widget::Move;
+  void Move(glm::vec2 relativePos) override;
 };
 
 class MusicTrackButton : public Widgets::Button {
@@ -26,6 +25,8 @@ class MusicTrackButton : public Widgets::Button {
   void Show() override;
   void Update(float dt) override;
   void Render() override;
+
+  using Widget::Move;
   void Move(glm::vec2 relativePosition) override;
 
   bool Selected = false;

--- a/src/games/chlcc/backlogmenu.cpp
+++ b/src/games/chlcc/backlogmenu.cpp
@@ -127,7 +127,7 @@ void BacklogMenu::Render() {
     Renderer->SetScissorRect(BacklogBackgroundSprite.Bounds);
     Renderer->DrawSprite(MenuTitleText, LeftTitlePos);
     Renderer->DisableScissor();
-    RenderHighlight();
+    RenderHighlight({0.0f, yOffset});
   }
   if (MenuTransition.Progress > 0.22f) {
     if (MenuTransition.Progress < 0.73f) {

--- a/src/games/chlcc/trophymenuentry.cpp
+++ b/src/games/chlcc/trophymenuentry.cpp
@@ -14,25 +14,25 @@ using namespace Impacto::AchievementSystem;
 
 TrophyMenuEntry::TrophyMenuEntry(int achievementId)
     : AchievementId(achievementId), Offset(0.0f, -Profile::DesignHeight) {
-  Position = glm::vec2(0.0f, 74.0f * (AchievementId % 6) + 130) + Offset;
+  Bounds.SetPos(glm::vec2(0.0f, 74.0f * (AchievementId % 6) + 130) + Offset);
 
   const auto* ach = AchievementSystem::GetAchievement(AchievementId);
   if (ach == nullptr) {
     NameLabel = Label(Vm::ScriptGetTextTableStrAddress(0, 19),
-                      Position + glm::vec2{218.0f, 13.0f}, 26,
+                      Bounds.GetPos() + glm::vec2{218.0f, 13.0f}, 26,
                       RendererOutlineMode::BottomRight, 0);
-    DescriptionLabel = Label("", Position + glm::vec2{218.0f, 43.0f}, 18,
+    DescriptionLabel = Label("", Bounds.GetPos() + glm::vec2{218.0f, 43.0f}, 18,
                              RendererOutlineMode::BottomRight, 0);
     Icon = DefaultTrophyIconSprite;
   } else {
-    NameLabel = Label(ach->Name(), Position + glm::vec2{218.0f, 13.0f}, 26,
-                      RendererOutlineMode::BottomRight, 0);
+    NameLabel = Label(ach->Name(), Bounds.GetPos() + glm::vec2{218.0f, 13.0f},
+                      26, RendererOutlineMode::BottomRight, 0);
     DescriptionLabel =
-        Label(ach->Description(), Position + glm::vec2{218.0f, 43.0f}, 18,
-              RendererOutlineMode::BottomRight, 0);
+        Label(ach->Description(), Bounds.GetPos() + glm::vec2{218.0f, 43.0f},
+              18, RendererOutlineMode::BottomRight, 0);
     Icon = ach->Icon();
   }
-  iconDest = {Position.x + 112.0f, Position.y + 4.0f, 64.0f, 64.0f};
+  iconDest = {Bounds.X + 112.0f, Bounds.Y + 4.0f, 64.0f, 64.0f};
 };
 
 void TrophyMenuEntry::UpdateOffset(glm::vec2 offset) {
@@ -45,7 +45,7 @@ void TrophyMenuEntry::Update(float dt) { Widget::Update(dt); }
 
 void TrophyMenuEntry::Render() {
   Renderer->DrawSprite(TrophyEntryCardSprite,
-                       Position + glm::vec2{91.0f, 0.0f});
+                       Bounds.GetPos() + glm::vec2{91.0f, 0.0f});
   Renderer->DrawSprite(Icon, iconDest);
   NameLabel.Render();
   DescriptionLabel.Render();
@@ -53,20 +53,10 @@ void TrophyMenuEntry::Render() {
 
 void TrophyMenuEntry::Move(glm::vec2 relativePosition) {
   Widget::Move(relativePosition);
-  Position += relativePosition;
+
   NameLabel.Move(relativePosition);
   DescriptionLabel.Move(relativePosition);
-  iconDest.X += relativePosition.x;
-  iconDest.Y += relativePosition.y;
-}
-
-void TrophyMenuEntry::MoveTo(glm::vec2 pos) {
-  Widget::MoveTo(pos);
-  Position = pos;
-  NameLabel.MoveTo(pos + glm::vec2{218.0f, 13.0f});
-  DescriptionLabel.MoveTo(pos + glm::vec2{218.0f, 43.0f});
-  iconDest.X = pos.x + 112.0f;
-  iconDest.Y = pos.y + 4.0f;
+  iconDest += relativePosition;
 }
 
 }  // namespace CHLCC

--- a/src/games/chlcc/trophymenuentry.h
+++ b/src/games/chlcc/trophymenuentry.h
@@ -16,13 +16,13 @@ class TrophyMenuEntry : public Widget {
   void Update(float dt) override;
   void UpdateInput(float dt) override {};
   void Render() override;
-  void Move(glm::vec2 relativePosition) override;
-  void MoveTo(glm::vec2 pos) override;
   void UpdateOffset(glm::vec2 offset);
+
+  using Widget::Move;
+  void Move(glm::vec2 relativePosition) override;
 
  private:
   int AchievementId;
-  glm::vec2 Position;
   Impacto::UI::Widgets::Label NameLabel;
   Impacto::UI::Widgets::Label DescriptionLabel;
   Impacto::Sprite Icon;

--- a/src/ui/backlogmenu.cpp
+++ b/src/ui/backlogmenu.cpp
@@ -253,7 +253,7 @@ void BacklogMenu::Update(float dt) {
   }
 }
 
-void BacklogMenu::RenderHighlight() const {
+void BacklogMenu::RenderHighlight(const glm::vec2 offset) const {
   if (EntryHighlightLocation == +EntryHighlightLocationType::None ||
       CurrentlyFocusedElement == nullptr ||
       !MainItems->RenderingBounds.Intersects(CurrentlyFocusedElement->Bounds))
@@ -286,7 +286,7 @@ void BacklogMenu::RenderHighlight() const {
   pos.Y += EntryHighlightOffset.y;
 
   float opacity = glm::smoothstep(0.0f, 1.0f, FadeAnimation.Progress);
-  Renderer->DrawSprite(EntryHighlight, pos,
+  Renderer->DrawSprite(EntryHighlight, pos + offset,
                        glm::vec4(1.0f, 1.0f, 1.0f, opacity));
 }
 

--- a/src/ui/backlogmenu.h
+++ b/src/ui/backlogmenu.h
@@ -46,7 +46,7 @@ class BacklogMenu : public Menu {
   TurboOnHoldHandler DirectionButtonHeldHandler;
   TurboOnHoldHandler PageUpDownButtonHeldHandler;
 
-  void RenderHighlight() const;
+  void RenderHighlight(glm::vec2 offset = {0.0f, 0.0f}) const;
 
   void UpdatePageUpDownInput(float dt);
   void UpdateScrollingInput(float dt);

--- a/src/ui/widget.cpp
+++ b/src/ui/widget.cpp
@@ -21,29 +21,9 @@ WidgetType Widget::GetType() { return WT_NORMAL; }
 void Widget::Move(glm::vec2 relativePosition, float duration) {
   MoveOrigin = Bounds.GetPos();
   MoveTarget = MoveOrigin + relativePosition;
-  MoveAnimation.Progress = 0.0f;
-  MoveAnimation.Direction = AnimationDirection::In;
+
   MoveAnimation.SetDuration(duration);
-  MoveAnimation.StartIn();
-}
-
-void Widget::Move(glm::vec2 relativePosition) {
-  Bounds.X += relativePosition.x;
-  Bounds.Y += relativePosition.y;
-}
-
-void Widget::MoveTo(glm::vec2 pos, float duration) {
-  MoveOrigin = Bounds.GetPos();
-  MoveTarget = pos;
-  MoveAnimation.Progress = 0.0f;
-  MoveAnimation.Direction = AnimationDirection::In;
-  MoveAnimation.SetDuration(duration);
-  MoveAnimation.StartIn();
-}
-
-void Widget::MoveTo(glm::vec2 pos) {
-  Bounds.X = pos.x;
-  Bounds.Y = pos.y;
+  MoveAnimation.StartIn(true);
 }
 
 Widget* Widget::GetFocus(FocusDirection dir) {

--- a/src/ui/widget.cpp
+++ b/src/ui/widget.cpp
@@ -21,6 +21,7 @@ WidgetType Widget::GetType() { return WT_NORMAL; }
 void Widget::Move(glm::vec2 relativePosition, float duration) {
   MoveOrigin = Bounds.GetPos();
   MoveTarget = MoveOrigin + relativePosition;
+  if (MoveToAnchor.has_value()) *MoveToAnchor += relativePosition;
 
   MoveAnimation.SetDuration(duration);
   MoveAnimation.StartIn(true);

--- a/src/ui/widget.h
+++ b/src/ui/widget.h
@@ -34,15 +34,20 @@ class Widget {
   // TODO: Text movement in widgets with text
   virtual void Move(glm::vec2 relativePosition) { Bounds += relativePosition; }
   void Move(glm::vec2 relativePosition, float duration);
-  void MoveTo(glm::vec2 pos) { Move(pos - Bounds.GetPos()); }
+  void MoveTo(glm::vec2 pos) {
+    Move(pos - MoveToAnchor.value_or(Bounds.GetPos()));
+  }
   void MoveTo(glm::vec2 pos, float duration) {
-    Move(pos - Bounds.GetPos(), duration);
+    Move(pos - MoveToAnchor.value_or(Bounds.GetPos()), duration);
   }
 
   virtual Widget* GetFocus(FocusDirection dir);
   virtual void SetFocus(Widget* widget, FocusDirection dir);
 
   RectF Bounds = RectF(0.0f, 0.0f, 0.0f, 0.0f);
+
+  // Will move this point to the desired location with MoveTo
+  std::optional<glm::vec2> MoveToAnchor;
 
   glm::vec2 MoveTarget;
   glm::vec2 MoveOrigin;

--- a/src/ui/widget.h
+++ b/src/ui/widget.h
@@ -32,10 +32,12 @@ class Widget {
   virtual WidgetType GetType();
 
   // TODO: Text movement in widgets with text
-  virtual void Move(glm::vec2 relativePosition, float duration);
-  virtual void Move(glm::vec2 relativePosition);
-  virtual void MoveTo(glm::vec2 pos, float duration);
-  virtual void MoveTo(glm::vec2 pos);
+  virtual void Move(glm::vec2 relativePosition) { Bounds += relativePosition; }
+  void Move(glm::vec2 relativePosition, float duration);
+  void MoveTo(glm::vec2 pos) { Move(pos - Bounds.GetPos()); }
+  void MoveTo(glm::vec2 pos, float duration) {
+    Move(pos - Bounds.GetPos(), duration);
+  }
 
   virtual Widget* GetFocus(FocusDirection dir);
   virtual void SetFocus(Widget* widget, FocusDirection dir);

--- a/src/ui/widgets/backlogentry.cpp
+++ b/src/ui/widgets/backlogentry.cpp
@@ -102,11 +102,6 @@ void BacklogEntry::Move(glm::vec2 relativePosition) {
   BacklogPage->Move(relativePosition);
 }
 
-void BacklogEntry::MoveTo(glm::vec2 position) {
-  glm::vec2 relativePosition = position - Position;
-  Move(relativePosition);
-}
-
 void BacklogEntry::Render() {
   if (AudioId != -1) {
     Renderer->DrawSprite(

--- a/src/ui/widgets/backlogentry.cpp
+++ b/src/ui/widgets/backlogentry.cpp
@@ -64,6 +64,8 @@ BacklogEntry::BacklogEntry(int id, Vm::BufferOffsetContext scrCtx, int audioId,
       break;
     }
   }
+
+  MoveToAnchor = Position;
   MoveTo(pos);
 }
 

--- a/src/ui/widgets/backlogentry.h
+++ b/src/ui/widgets/backlogentry.h
@@ -20,8 +20,8 @@ class BacklogEntry : public Widget {
   void UpdateInput(float dt) override;
   void Render() override;
 
+  using Widget::Move;
   void Move(glm::vec2 relativePosition) override;
-  void MoveTo(glm::vec2 position) override;
 
   int Id;
   int AudioId = -1;

--- a/src/ui/widgets/button.cpp
+++ b/src/ui/widgets/button.cpp
@@ -129,25 +129,11 @@ void Button::SetText(std::vector<ProcessedTextGlyph> text, float textWidth,
 void Button::Move(glm::vec2 relativePosition) {
   if (HasText) {
     for (ProcessedTextGlyph& glyph : Text) {
-      glyph.DestRect.X += relativePosition.x;
-      glyph.DestRect.Y += relativePosition.y;
+      glyph.DestRect += relativePosition;
     }
   }
   Widget::Move(relativePosition);
   if (HoverBounds != RectF{}) HoverBounds += relativePosition;
-}
-
-void Button::Move(glm::vec2 relativePosition, float duration) {
-  Widget::Move(relativePosition, duration);
-}
-
-void Button::MoveTo(glm::vec2 pos) {
-  auto relativePosition = pos - glm::vec2(Bounds.X, Bounds.Y);
-  Move(relativePosition);
-}
-
-void Button::MoveTo(glm::vec2 pos, float duration) {
-  Widget::MoveTo(pos, duration);
 }
 
 }  // namespace Widgets

--- a/src/ui/widgets/button.h
+++ b/src/ui/widgets/button.h
@@ -19,10 +19,9 @@ class Button : public Widget {
 
   virtual void UpdateInput(float dt) override;
   virtual void Render() override;
+
+  using Widget::Move;
   virtual void Move(glm::vec2 relativePosition) override;
-  virtual void Move(glm::vec2 relativePosition, float duration) override;
-  virtual void MoveTo(glm::vec2 pos) override;
-  virtual void MoveTo(glm::vec2 pos, float duration) override;
 
   void SetText(Vm::BufferOffsetContext scrCtx, float fontSize,
                RendererOutlineMode outlineMode, int colorIndex = 10);

--- a/src/ui/widgets/cclcc/optionsbinarybutton.cpp
+++ b/src/ui/widgets/cclcc/optionsbinarybutton.cpp
@@ -100,13 +100,6 @@ void OptionsBinaryButton::Move(glm::vec2 relativePos) {
   FalseButton.Move(relativePos);
 }
 
-void OptionsBinaryButton::MoveTo(glm::vec2 pos) {
-  const glm::vec2 relativePosition = pos - Bounds.GetPos();
-  OptionsEntry::MoveTo(pos);
-  TrueButton.Move(relativePosition);
-  FalseButton.Move(relativePosition);
-}
-
 void OptionsBinaryButton::TrueOnClick(ClickArea* target) {
   if (Selected && State != true)
     Audio::Channels[Audio::AC_SSE]->Play("sysse", 1, false, 0.0f);

--- a/src/ui/widgets/cclcc/optionsbinarybutton.h
+++ b/src/ui/widgets/cclcc/optionsbinarybutton.h
@@ -24,8 +24,8 @@ class OptionsBinaryButton : public OptionsEntry {
   void Show() override;
   void Hide() override;
 
+  using Widget::Move;
   void Move(glm::vec2 relativePos) override;
-  void MoveTo(glm::vec2 pos) override;
 
  private:
   ClickArea TrueButton;

--- a/src/ui/widgets/cclcc/optionsentry.cpp
+++ b/src/ui/widgets/cclcc/optionsentry.cpp
@@ -90,12 +90,6 @@ void OptionsEntry::Move(glm::vec2 relativePos) {
   EntryButton.Move(relativePos);
 }
 
-void OptionsEntry::MoveTo(glm::vec2 pos) {
-  const glm::vec2 relativePosition = pos - Bounds.GetPos();
-  Widget::MoveTo(pos);
-  EntryButton.Move(relativePosition);
-}
-
 void OptionsEntry::EntryButtonOnClick(ClickArea* target) {
   if (Selected) return;
 

--- a/src/ui/widgets/cclcc/optionsentry.h
+++ b/src/ui/widgets/cclcc/optionsentry.h
@@ -24,8 +24,8 @@ class OptionsEntry : public Widget {
   void Show() override;
   void Hide() override;
 
+  using Widget::Move;
   void Move(glm::vec2 relativePos) override;
-  void MoveTo(glm::vec2 pos) override;
 
   bool Selected = false;
 

--- a/src/ui/widgets/cclcc/optionsslider.cpp
+++ b/src/ui/widgets/cclcc/optionsslider.cpp
@@ -70,12 +70,6 @@ void OptionsSlider::Move(glm::vec2 relativePos) {
   Slider.Move(relativePos);
 }
 
-void OptionsSlider::MoveTo(glm::vec2 pos) {
-  const glm::vec2 relativePosition = pos - Bounds.GetPos();
-  OptionsEntry::MoveTo(pos);
-  Slider.Move(relativePosition);
-}
-
 }  // namespace CCLCC
 }  // namespace Widgets
 }  // namespace UI

--- a/src/ui/widgets/cclcc/optionsslider.h
+++ b/src/ui/widgets/cclcc/optionsslider.h
@@ -20,8 +20,8 @@ class OptionsSlider : public OptionsEntry {
   void Update(float dt) override;
   void UpdateInput(float dt) override;
 
+  using Widget::Move;
   void Move(glm::vec2 relativePos) override;
-  void MoveTo(glm::vec2 pos) override;
 
  protected:
   OptionsSlider(float& value, float min, float max, const Sprite& box,

--- a/src/ui/widgets/cclcc/optionsvoiceslider.cpp
+++ b/src/ui/widgets/cclcc/optionsvoiceslider.cpp
@@ -98,12 +98,6 @@ void OptionsVoiceSlider::Move(glm::vec2 relativePos) {
   MuteButton.Move(relativePos);
 }
 
-void OptionsVoiceSlider::MoveTo(glm::vec2 pos) {
-  const glm::vec2 relativePosition = pos - Bounds.GetPos();
-  OptionsSlider::MoveTo(pos);
-  MuteButton.Move(relativePosition);
-}
-
 void OptionsVoiceSlider::MuteButtonOnClick(ClickArea* target) {
   if (HasFocus) Audio::Channels[Audio::AC_SSE]->Play("sysse", 2, false, 0.0f);
 

--- a/src/ui/widgets/cclcc/optionsvoiceslider.h
+++ b/src/ui/widgets/cclcc/optionsvoiceslider.h
@@ -23,8 +23,8 @@ class OptionsVoiceSlider : public OptionsSlider {
   void Show() override;
   void Hide() override;
 
+  using Widget::Move;
   void Move(glm::vec2 relativePos) override;
-  void MoveTo(glm::vec2 pos) override;
 
  private:
   const Sprite& Portrait;

--- a/src/ui/widgets/cclcc/saveentrybutton.cpp
+++ b/src/ui/widgets/cclcc/saveentrybutton.cpp
@@ -140,19 +140,6 @@ void SaveEntryButton::Move(glm::vec2 relativePosition) {
   BrokenDataSymbol.Move(relativePosition);
 }
 
-void SaveEntryButton::MoveTo(glm::vec2 position) {
-  Button::MoveTo(position);
-  NormalSpriteLabel.MoveTo(position);
-  FocusedSpriteLabel.MoveTo(position);
-  LockedSymbol.MoveTo(position);
-  CharacterRouteLabel.MoveTo(position);
-  SceneTitleLabel.MoveTo(position);
-  SaveDateLabel.MoveTo(position);
-  Thumbnail.MoveTo(position);
-  NoDataSymbol.MoveTo(position);
-  BrokenDataSymbol.MoveTo(position);
-}
-
 void SaveEntryButton::RefreshCharacterRouteText(int strIndex) {
   auto strAddr = Vm::ScriptGetTextTableStrAddress(1, strIndex);
   float fontSize = 28;

--- a/src/ui/widgets/cclcc/saveentrybutton.h
+++ b/src/ui/widgets/cclcc/saveentrybutton.h
@@ -20,8 +20,9 @@ class SaveEntryButton : public Widgets::Button {
                   Sprite noDataSprite, Sprite brokenDataSprite);
 
   void Render() override;
+
+  using Widget::Move;
   void Move(glm::vec2 pos) override;
-  void MoveTo(glm::vec2 pos) override;
 
   int GetPage() const;
 

--- a/src/ui/widgets/cclcc/tipsentrybutton.cpp
+++ b/src/ui/widgets/cclcc/tipsentrybutton.cpp
@@ -117,11 +117,6 @@ void TipsEntryButton::Move(glm::vec2 relativePos) {
   }
 }
 
-void TipsEntryButton::MoveTo(glm::vec2 pos) {
-  auto relativePos = pos - glm::vec2(Bounds.X, Bounds.Y);
-  Move(relativePos);
-}
-
 }  // namespace CCLCC
 }  // namespace Widgets
 }  // namespace UI

--- a/src/ui/widgets/cclcc/tipsentrybutton.h
+++ b/src/ui/widgets/cclcc/tipsentrybutton.h
@@ -18,8 +18,9 @@ class TipsEntryButton : public Widgets::Button {
   void Update(float dt) override;
   void UpdateInput(float dt) override;
   void Render() override;
+
+  using Widget::Move;
   void Move(glm::vec2 pos) override;
-  void MoveTo(glm::vec2 pos) override;
 
   TipsSystem::TipsDataRecord const* TipEntryRecord;
   bool PrevFocusState = false;

--- a/src/ui/widgets/chlcc/saveentrybutton.h
+++ b/src/ui/widgets/chlcc/saveentrybutton.h
@@ -43,6 +43,8 @@ class SaveEntryButton : public Widgets::Button {
                          RendererOutlineMode outlineMode,
                          glm::vec2 relativeTitlePosition, int colorIndex);
   void AddThumbnail(Sprite thumbnail, glm::vec2 pos);
+
+  using Widget::Move;
   void Move(glm::vec2 pos) override;
 
   static void FocusedAlphaFadeStart();

--- a/src/ui/widgets/group.cpp
+++ b/src/ui/widgets/group.cpp
@@ -171,22 +171,6 @@ void Group::Move(glm::vec2 relativePosition) {
   Widget::Move(relativePosition);
 }
 
-void Group::MoveTo(glm::vec2 pos) {
-  auto relativePosition = pos - glm::vec2(Bounds.X, Bounds.Y);
-  for (const auto& el : Children) {
-    el->Move(relativePosition);
-  }
-  Widget::MoveTo(pos);
-}
-
-void Group::Move(glm::vec2 relativePosition, float duration) {
-  Widget::Move(relativePosition, duration);
-}
-
-void Group::MoveTo(glm::vec2 pos, float duration) {
-  Widget::MoveTo(pos, duration);
-}
-
 void Group::Clear() {
   for (auto el : Children) {
     delete el;

--- a/src/ui/widgets/group.cpp
+++ b/src/ui/widgets/group.cpp
@@ -108,12 +108,10 @@ void Group::Render() {
     Renderer->EnableScissor();
     Renderer->SetScissorRect(RenderingBounds);
     for (const auto& el : Children) {
-      if (RenderingBounds.Intersects(el->Bounds)) {
-        auto tint = el->Tint;
-        el->Tint *= Tint;
-        el->Render();
-        el->Tint = tint;
-      }
+      auto tint = el->Tint;
+      el->Tint *= Tint;
+      el->Render();
+      el->Tint = tint;
     }
     Renderer->DisableScissor();
   }

--- a/src/ui/widgets/group.h
+++ b/src/ui/widgets/group.h
@@ -40,10 +40,8 @@ class Group : public Widget {
 
   void Clear();
 
+  using Widget::Move;
   void Move(glm::vec2 relativePosition) override;
-  void MoveTo(glm::vec2 pos) override;
-  void Move(glm::vec2 relativePosition, float duration) override;
-  void MoveTo(glm::vec2 pos, float duration) override;
 
   Widget* GetFirstFocusableChild();
 

--- a/src/ui/widgets/label.cpp
+++ b/src/ui/widgets/label.cpp
@@ -85,15 +85,9 @@ void Label::Render() {
 
 void Label::Move(glm::vec2 relativePosition) {
   for (ProcessedTextGlyph& glyph : Text) {
-    glyph.DestRect.X += relativePosition.x;
-    glyph.DestRect.Y += relativePosition.y;
+    glyph.DestRect += relativePosition;
   }
   Widget::Move(relativePosition);
-}
-
-void Label::MoveTo(glm::vec2 pos) {
-  auto relativePosition = pos - glm::vec2(Bounds.X, Bounds.Y);
-  Move(relativePosition);
 }
 
 void Label::SetSprite(Sprite const& label) {

--- a/src/ui/widgets/label.h
+++ b/src/ui/widgets/label.h
@@ -35,8 +35,9 @@ class Label : public Widget {
   void Update(float dt) override;
   void UpdateInput(float dt) override;
   void Render() override;
+
+  using Widget::Move;
   void Move(glm::vec2 relativePosition) override;
-  void MoveTo(glm::vec2 pos) override;
 
   void SetSprite(Sprite const& label);
   void SetText(std::vector<ProcessedTextGlyph> text, float textWidth,

--- a/src/ui/widgets/mo6tw/albumthumbnailbutton.cpp
+++ b/src/ui/widgets/mo6tw/albumthumbnailbutton.cpp
@@ -57,11 +57,6 @@ void AlbumThumbnailButton::Move(glm::vec2 relativePosition) {
   Widget::Move(relativePosition);
 }
 
-void AlbumThumbnailButton::MoveTo(glm::vec2 pos) {
-  InfoText->MoveTo(pos);
-  Widget::MoveTo(pos);
-}
-
 }  // namespace MO6TW
 }  // namespace Widgets
 }  // namespace UI

--- a/src/ui/widgets/mo6tw/albumthumbnailbutton.h
+++ b/src/ui/widgets/mo6tw/albumthumbnailbutton.h
@@ -18,8 +18,9 @@ class AlbumThumbnailButton : public ImageThumbnailButton {
                        int unlockedVariations, int totalVariations,
                        glm::vec2 pos);
   void Render() override;
+
+  using Widget::Move;
   void Move(glm::vec2 relativePosition) override;
-  void MoveTo(glm::vec2 pos) override;
 
  private:
   Sprite Border;

--- a/src/ui/widgets/mo6tw/scenelistentry.cpp
+++ b/src/ui/widgets/mo6tw/scenelistentry.cpp
@@ -36,14 +36,8 @@ void SceneListEntry::Move(glm::vec2 relativePosition) {
   Number->Move(relativePosition);
   LockedText->Move(relativePosition);
   UnlockedText->Move(relativePosition);
-  Widget::Move(relativePosition);
-}
 
-void SceneListEntry::MoveTo(glm::vec2 pos) {
-  Number->MoveTo(pos);
-  LockedText->MoveTo(pos);
-  UnlockedText->MoveTo(pos);
-  Widget::MoveTo(pos);
+  Widget::Move(relativePosition);
 }
 
 }  // namespace MO6TW

--- a/src/ui/widgets/mo6tw/scenelistentry.h
+++ b/src/ui/widgets/mo6tw/scenelistentry.h
@@ -14,8 +14,9 @@ class SceneListEntry : public Widgets::Button {
                  Widgets::Label* unlockedText, Sprite const& highlight,
                  bool isLocked);
   void Render() override;
+
+  using Widget::Move;
   void Move(glm::vec2 relativePosition) override;
-  void MoveTo(glm::vec2 pos) override;
 
   bool IsLocked = false;
 

--- a/src/ui/widgets/scrollbar.cpp
+++ b/src/ui/widgets/scrollbar.cpp
@@ -174,15 +174,8 @@ void Scrollbar::Render() {
 }
 
 void Scrollbar::Move(glm::vec2 relativePosition) {
-  TrackBounds.X += relativePosition.x;
-  TrackBounds.Y += relativePosition.y;
-  ThumbBounds.X += relativePosition.x;
-  ThumbBounds.Y += relativePosition.y;
-}
-
-void Scrollbar::MoveTo(glm::vec2 pos) {
-  auto relativePosition = pos - glm::vec2(Bounds.X, Bounds.Y);
-  Move(relativePosition);
+  TrackBounds += relativePosition;
+  ThumbBounds += relativePosition;
 }
 
 void Scrollbar::ClampValue() {

--- a/src/ui/widgets/scrollbar.h
+++ b/src/ui/widgets/scrollbar.h
@@ -31,8 +31,8 @@ class Scrollbar : public Widget {
   virtual void Update(float dt) override;
   virtual void Render() override;
 
+  using Widget::Move;
   void Move(glm::vec2 relativePosition) override;
-  void MoveTo(glm::vec2 pos) override;
 
   void ClampValue();
   float GetNormalizedValue() const {

--- a/src/util.h
+++ b/src/util.h
@@ -163,7 +163,18 @@ struct RectF {
   }
 
   constexpr glm::vec2 GetPos() const { return glm::vec2(X, Y); }
+  void SetPos(float x, float y) {
+    X = x;
+    Y = y;
+  }
+  void SetPos(glm::vec2 position) { SetPos(position.x, position.y); }
+
   constexpr glm::vec2 GetSize() const { return glm::vec2(Width, Height); }
+  void SetSize(float width, float height) {
+    Width = width;
+    Height = height;
+  }
+  void SetSize(glm::vec2 size) { SetSize(size.x, size.y); }
 
   static RectF Coalesce(const RectF& first, const RectF& second);
   static RectF BoundingBox(const RectF& first, const CornersQuad& second);

--- a/src/util.h
+++ b/src/util.h
@@ -103,6 +103,16 @@ struct RectF {
       : X(x), Y(y), Width(width), Height(height) {}
   constexpr RectF(Rect const& rect);
 
+  constexpr float Left() const { return X; }
+  constexpr float Right() const { return X + Width; }
+  constexpr float Top() const { return Y; }
+  constexpr float Bottom() const { return Y + Height; }
+
+  constexpr glm::vec2 TopLeft() const { return {Left(), Top()}; }
+  constexpr glm::vec2 TopRight() const { return {Right(), Top()}; }
+  constexpr glm::vec2 BottomRight() const { return {Right(), Bottom()}; }
+  constexpr glm::vec2 BottomLeft() const { return {Left(), Bottom()}; }
+
   // RectF is rotated around center
   constexpr glm::vec2 Center() const {
     return glm::vec2(X + Width / 2.0f, Y + Height / 2.0f);
@@ -119,13 +129,13 @@ struct RectF {
   }
 
   constexpr bool Intersects(RectF const& rect) const {
-    return (X <= rect.X + rect.Width && rect.X <= X + Width &&
-            Y <= rect.Y + rect.Height && rect.Y <= Y + Height);
+    return (Left() <= rect.Right() && Right() >= rect.Left() &&
+            Top() <= rect.Bottom() && Bottom() >= rect.Top());
   }
 
   constexpr bool Contains(RectF const& rect) const {
-    return (X <= rect.X && rect.X + rect.Width <= X + Width && Y <= rect.Y &&
-            rect.Y + rect.Height <= Y + Height);
+    return (Left() <= rect.Left() && rect.Right() <= Right() &&
+            Top() <= rect.Top() && rect.Bottom() <= Bottom());
   }
 
   constexpr RectF operator+(const glm::vec2 movementVector) const {
@@ -216,6 +226,16 @@ struct Rect {
   constexpr Rect(RectF const& rect)
       : Rect((int)rect.X, (int)rect.Y, (int)rect.Width, (int)rect.Height) {}
 
+  constexpr int Left() const { return X; }
+  constexpr int Right() const { return X + Width; }
+  constexpr int Top() const { return Y; }
+  constexpr int Bottom() const { return Y + Height; }
+
+  constexpr glm::ivec2 TopLeft() const { return {Left(), Top()}; }
+  constexpr glm::ivec2 TopRight() const { return {Right(), Top()}; }
+  constexpr glm::ivec2 BottomRight() const { return {Right(), Bottom()}; }
+  constexpr glm::ivec2 BottomLeft() const { return {Left(), Bottom()}; }
+
   // Rect is rotated around center
   constexpr glm::ivec2 Center() const {
     return glm::ivec2(X + Width / 2, Y + Height / 2);
@@ -230,8 +250,8 @@ struct Rect {
   }
 
   constexpr bool Intersects(Rect const& rect) const {
-    return (X <= rect.X + rect.Width && rect.X <= X + Width &&
-            Y <= rect.Y + rect.Height && rect.Y <= Y + Height);
+    return (Left() <= rect.Right() && Right() >= rect.Left() &&
+            Top() <= rect.Bottom() && Bottom() >= rect.Top());
   }
 
   constexpr bool operator==(Rect const& other) const {


### PR DESCRIPTION
Changes the `Widget` class's Move API such that only `Move(glm::vec2 offset)` ever needs to be overridden—with `MoveTo` and the timed Move(To)s being supplied automatically

- Adds optional anchor point for `MoveTo` to set to the desired position instead of the usual `Bounds.GetPos()`
- Removes all superfluous (and sometimes wrong) `MoveTo` overrides
- Removes `RenderingBounds` check in `Group::Render` as it does not take out-of-`Bounds` rendering into account (and should really only be checked by the renderer anyway)
- Adds a few useful methods to `RectF` and `Rect`
- ~~Free small C;H LCC trophy menu refactor I did while debugging an issue I introduced to it \o/ (feel free to reject as the issue was not actually in the trophy menu itself)~~