### PR TITLE
[C;CLCC] Fix blinking on PressToStart Part 2

### DIFF
--- a/src/games/cclcc/titlemenu.cpp
+++ b/src/games/cclcc/titlemenu.cpp
@@ -395,6 +395,7 @@ void TitleMenu::ExplodeScreenUpdate() {
   if (TitleAnimation.IsOut() && !IsExploding) {
     TitleAnimation.StartIn();
     IsExploding = true;
+    EverExploded = true;
   }
   if (TitleAnimation.IsIn() && !IsExploding) {
     TitleAnimation.StartOut();
@@ -534,7 +535,7 @@ void TitleMenu::Render() {
                       1.0f - ScrWork[SW_TITLEDISPCT] / 60.0f));
       } break;
       case 2: {  // Transition between Press to start and menus
-        if (IsExploding) {
+        if (IsExploding || EverExploded) {
           DrawMainMenuBackGraphics();
         } else {
           DrawDISwordBackground();

--- a/src/games/cclcc/titlemenu.h
+++ b/src/games/cclcc/titlemenu.h
@@ -68,10 +68,11 @@ class TitleMenu : public Menu {
   void SubMenuUpdate();
   void ExplodeScreenUpdate();
   void ReturnToMenuUpdate();
+  MenuState SubMenuState = Hidden;
+  bool EverExploded = false;
+  bool IsExploding = false;
   bool InputLocked = false;
   bool PrevInputLocked = false;
-  MenuState SubMenuState = Hidden;
-  bool IsExploding = false;
 };
 
 }  // namespace CCLCC


### PR DESCRIPTION
Apparently animation can be played backward, that I didn't account for in the previous PR and it can blink again in a different way

- Support backward animation case
- Reorder fields for better alignment (-8 bytes to struct size)

<h2> Dev Proof </h2>

Probably it breaks only on first closure

https://github.com/user-attachments/assets/ff8b8489-6b34-4b83-bd7f-cc04860f3db2

https://github.com/user-attachments/assets/94fde571-6557-4ddc-bd88-2918aead29dd



