### PR TITLE
C;H LCC script crash fixes

### DIFF
--- a/src/games/chlcc/titlemenu.cpp
+++ b/src/games/chlcc/titlemenu.cpp
@@ -264,6 +264,11 @@ void TitleMenu::Hide() {
       UI::FocusedMenu = 0;
     }
     IsFocused = false;
+
+    MainItems->Hide();
+    LoadItems->Hide();
+    SystemItems->Hide();
+    UnlockedExtraItems->Hide();
   }
 }
 
@@ -317,6 +322,7 @@ void TitleMenu::Update(float dt) {
 
         IntroSequence.Update(dt);
 
+        MainItems->Hide();
         // When returning to title menu from loading a game we need to hide the
         // load sub-menu
         if (LoadItems->IsShown) {

--- a/src/text.cpp
+++ b/src/text.cpp
@@ -123,7 +123,7 @@ int StringToken::Read(Vm::Sc3VmThread* ctx) {
       } else {
         uint32_t oldIp = ctx->IpOffset;
         // TODO is this really okay to do in parsing code?
-        Vm::ExpressionEval(ctx, &Val_Expr);
+        Val_Expr = Vm::ExpressionEval(ctx);
         bytesRead += (int)(ctx->IpOffset - oldIp);
       }
       break;
@@ -133,7 +133,7 @@ int StringToken::Read(Vm::Sc3VmThread* ctx) {
       Type = (StringTokenType)c;
       uint32_t oldIp = ctx->IpOffset;
       // TODO is this really okay to do in parsing code?
-      Vm::ExpressionEval(ctx, &Val_Expr);
+      Val_Expr = Vm::ExpressionEval(ctx);
       bytesRead += (int)(ctx->IpOffset - oldIp);
       break;
     }

--- a/src/vm/expression.cpp
+++ b/src/vm/expression.cpp
@@ -94,16 +94,14 @@ class ExpressionParser {
 };
 
 int ExpressionEval(Sc3VmThread* thd, int* result) {
-  ExpressionParser* parser = new ExpressionParser(thd);
+  std::unique_ptr<ExpressionParser> parser =
+      std::make_unique<ExpressionParser>(thd);
 
   ExpressionNode* root = parser->ParseSubExpression(0);
-
   std::unique_ptr<ExpressionNode> rootPtr =
       std::unique_ptr<ExpressionNode>(root);
 
-  *result = rootPtr->Evaluate(thd);
-
-  delete parser;
+  *result = root == nullptr ? 0 : rootPtr->Evaluate(thd);
 
   return 0;
 }
@@ -399,6 +397,8 @@ ExpressionNode* ExpressionParser::ParseSubExpression(int minPrecidence) {
 }
 
 ExpressionNode* ExpressionParser::ParseTerm() {
+  if (Tokens.empty()) return nullptr;
+
   ExprToken tok = Tokens[CurrentToken++];
   ExpressionNode* term = nullptr;
   switch (tok.Type) {

--- a/src/vm/expression.cpp
+++ b/src/vm/expression.cpp
@@ -93,7 +93,7 @@ class ExpressionParser {
   ExpressionNode* ParseTerm();
 };
 
-int ExpressionEval(Sc3VmThread* thd, int* result) {
+int ExpressionEval(Sc3VmThread* thd) {
   std::unique_ptr<ExpressionParser> parser =
       std::make_unique<ExpressionParser>(thd);
 
@@ -101,9 +101,7 @@ int ExpressionEval(Sc3VmThread* thd, int* result) {
   std::unique_ptr<ExpressionNode> rootPtr =
       std::unique_ptr<ExpressionNode>(root);
 
-  *result = root == nullptr ? 0 : rootPtr->Evaluate(thd);
-
-  return 0;
+  return root == nullptr ? 0 : rootPtr->Evaluate(thd);
 }
 
 int ExpressionNode::Evaluate(Sc3VmThread* thd) {

--- a/src/vm/expression.h
+++ b/src/vm/expression.h
@@ -7,7 +7,7 @@ namespace Impacto {
 
 namespace Vm {
 
-int ExpressionEval(Sc3VmThread* thread, int* result);
+int ExpressionEval(Sc3VmThread* thread);
 
 }  // namespace Vm
 

--- a/src/vm/inst_dialogue.cpp
+++ b/src/vm/inst_dialogue.cpp
@@ -164,8 +164,8 @@ VmInstruction(InstMes) {
 
   int audioId = -1;
   int animationId = 0;
-  if (voiced) ExpressionEval(thread, &audioId);
-  if (acted) ExpressionEval(thread, &animationId);
+  if (voiced) audioId = ExpressionEval(thread);
+  if (acted) animationId = ExpressionEval(thread);
   PopExpression(characterId);
   if (characterId >= 32) characterId = 0;
   PopUint16(lineId);
@@ -640,18 +640,18 @@ VmInstruction(InstSetRevMes) {
   int audioId = -1;
   int animationId = 0;
   if (voiced) {
-    ExpressionEval(thread, &audioId);
-    ExpressionEval(thread, &animationId);
+    audioId = ExpressionEval(thread);
+    animationId = ExpressionEval(thread);
   }
 
-  int savePtr = 0;
   if (savep) {
-    ExpressionEval(thread, &savePtr);
+    // TODO: use?
+    ExpressionEval(thread);
   }
 
   int lineId;
   if (expression) {
-    ExpressionEval(thread, &lineId);
+    lineId = ExpressionEval(thread);
   } else {
     PopUint16(lineIdTemp);
     lineId = lineIdTemp;

--- a/src/vm/inst_dialogue.cpp
+++ b/src/vm/inst_dialogue.cpp
@@ -51,7 +51,30 @@ VmInstruction(InstSetMesWinPri) {
              "{:d}, unused: {:d})\n",
              arg1, arg2, unused);
 }
-VmInstruction(InstMesSync) {}
+VmInstruction(InstMesSync) {
+  StartInstruction;
+
+  PopUint8(type);
+  switch (type) {
+    case 0:
+    case 1:
+    case 2:
+    case 3:
+    case 4:
+    case 11:
+    case 12:
+    case 13:
+    case 14:
+    case 20:
+      break;
+    case 10: {
+      PopExpression(unknown);
+    } break;
+  }
+
+  ImpLogSlow(LogLevel::Warning, LogChannel::VMStub,
+             "STUB instruction MesSync(type: {:d})\n", type);
+}
 VmInstruction(InstMesSetID) {
   StartInstruction;
   PopUint8(type);

--- a/src/vm/inst_graphics2d.cpp
+++ b/src/vm/inst_graphics2d.cpp
@@ -145,7 +145,7 @@ VmInstruction(InstBGsetLink) {
   PopExpression(arg2);
   int arg3 = 0;
   if (id >= 4) {
-    ExpressionEval(thread, &arg3);
+    arg3 = ExpressionEval(thread);
     id -= 4;
   }
   PopExpression(arg4);

--- a/src/vm/inst_graphics3d.cpp
+++ b/src/vm/inst_graphics3d.cpp
@@ -308,8 +308,8 @@ VmInstruction(InstUnk0210) {
   PopExpression(arg2);
   int arg3, arg4;
   if (arg1 & 0x10) {
-    ExpressionEval(thread, &arg3);
-    ExpressionEval(thread, &arg4);
+    arg3 = ExpressionEval(thread);
+    arg4 = ExpressionEval(thread);
   } else {
     arg3 = 0;
     arg4 = 0;

--- a/src/vm/inst_macros.inc
+++ b/src/vm/inst_macros.inc
@@ -33,9 +33,7 @@
     name = ScriptGetLabelAddress(scriptBufferId, labelNum); \
   }                                                         \
   (void)0
-#define PopExpression(name) \
-  int name;                 \
-  ExpressionEval(thread, &name)
+#define PopExpression(name) [[maybe_unused]] int name = ExpressionEval(thread)
 #define PopString(name)                                            \
   uint32_t name;                                                   \
   {                                                                \

--- a/src/vm/inst_misc.cpp
+++ b/src/vm/inst_misc.cpp
@@ -574,6 +574,13 @@ VmInstruction(InstTitleMenuNew) {
 }
 VmInstruction(InstTitleMenuOld) {
   StartInstruction;
+
+  if (UI::TitleMenuPtr == nullptr) return;
+
+  if (ScrWork[SW_TITLECUR1] == 0xff) {
+    ScrWork[SW_TITLECUR1] = 0;
+  }
+
   // Sometimes in order to make something sane
   // you have to sacrifice the sanity of others...
   if (!UI::TitleMenuPtr->ChoiceMade) {
@@ -586,14 +593,6 @@ VmInstruction(InstTitleMenuOld) {
     UI::TitleMenuPtr->ChoiceMade = false;
     Interface::PADinputButtonWentDown |= Interface::PAD1A;
   }
-
-  // if (TitleMenu::Implementation != 0) {
-  //  // ScrWork[SW_TITLECUR1] = TitleMenu::Implementation->CurrentChoice;
-  //  ScrWork[SW_TITLECUR2] = TitleMenu::Implementation->SecondaryChoice;
-  //} else {
-  //  // ScrWork[SW_TITLECUR1] = 0;
-  //  ScrWork[SW_TITLECUR2] = 255;
-  //}
 }
 VmInstruction(InstSetPlayMode) {
   StartInstruction;

--- a/src/vm/thread.cpp
+++ b/src/vm/thread.cpp
@@ -45,7 +45,7 @@ void* Sc3VmThread::GetMemberPointer(uint32_t offset) {
 }
 
 uint8_t* Sc3VmThread::GetIp() const {
-  return ScriptBuffers[ScriptBufferId].data() + IpOffset;
+  return &ScriptBuffers[ScriptBufferId][IpOffset];
 }
 void Sc3VmThread::SetIp(uint8_t* ptr) {
   assert(ptr >= ScriptBuffers[ScriptBufferId].data() &&
@@ -55,6 +55,7 @@ void Sc3VmThread::SetIp(uint8_t* ptr) {
 }
 
 void Sc3VmThread::SetIp(BufferOffsetContext ctx) {
+  assert(ctx.IpOffset < ScriptBuffers[ctx.ScriptBufferId].size());
   IpOffset = ctx.IpOffset;
   ScriptBufferId = ctx.ScriptBufferId;
 }

--- a/src/vm/vm.cpp
+++ b/src/vm/vm.cpp
@@ -438,7 +438,6 @@ void RunThread(Sc3VmThread* thread) {
   uint32_t opcodeGrp;
   uint32_t opcode;
   uint32_t opcodeGrp1;
-  int calDummy;
 
   ImpLog(LogLevel::Trace, LogChannel::VM, "Running thread ID = {:d}\n",
          thread->Id);
@@ -477,7 +476,7 @@ void RunThread(Sc3VmThread* thread) {
     opcodeGrp = *scrVal;
     if ((uint8_t)opcodeGrp == 0xFE) {
       thread->IpOffset += 1;
-      ExpressionEval(thread, &calDummy);
+      ExpressionEval(thread);
     } else {
       opcode = *(scrVal + 1);
       opcodeGrp1 = opcodeGrp & 0x7F;


### PR DESCRIPTION
- Fixes crash on butterfly scene in Ayase route
  - Gracefully handles empty script expressions
  - Adds stub for InstMesSync
- Fixes crash upon returning to the title screen in C;H LCC
- Properly resets selected element when exiting title screen