### PR TITLE
[CCLCC] Audio fixes and additions.

### DIFF
--- a/src/games/cc/sysmesbox.cpp
+++ b/src/games/cc/sysmesbox.cpp
@@ -21,6 +21,7 @@ static float BoxAnimCount = 0.0f;
 
 void SysMesBox::ChoiceItemOnClick(Button* target) {
   ScrWork[SW_SYSSEL] = target->Id;
+  Audio::Channels[Audio::AC_SSE]->Play("sysse", 2, false, 0);
   ChoiceMade = true;
 }
 

--- a/src/games/cclcc/helpmenu.cpp
+++ b/src/games/cclcc/helpmenu.cpp
@@ -50,6 +50,7 @@ void HelpMenu::Hide() {
     State = Hiding;
     FadeAnimation.StartOut();
     NextPageAnimation.StartOut();
+    Audio::Channels[Audio::AC_SSE]->Play("sysse", 3, false, 0);
     if (LastFocusedMenu != 0) {
       UI::FocusedMenu = LastFocusedMenu;
     } else {

--- a/src/games/cclcc/systemmenu.cpp
+++ b/src/games/cclcc/systemmenu.cpp
@@ -24,6 +24,7 @@ void SystemMenu::MenuButtonOnClick(Widgets::Button* target) {
   // is case 0)
   SaveMenuPtr->ActiveMenuType =
       SaveMenuPageType::_from_integral_nothrow(target->Id % 4);
+  Audio::Channels[Audio::AC_SSE]->Play("sysse", 2, false, 0);
   ChoiceMade = true;
 }
 

--- a/src/games/cclcc/tipsmenu.cpp
+++ b/src/games/cclcc/tipsmenu.cpp
@@ -178,6 +178,7 @@ void TipsMenu::Hide() {
   if (State != Hidden) {
     State = Hiding;
     FadeAnimation.StartOut();
+    Audio::Channels[Audio::AC_SSE]->Play("sysse", 3, false, 0);
     if (ScrWork[SW_SYSSUBMENUCT] != 0) {
       TransitionAnimation.StartOut();
     } else {


### PR DESCRIPTION
This PR will:
- Fix issue #265 (hiding audio was added).
- Add entering audio for buttons in SystemMenu (Backlog, Save, Load, Tips Menu, etc., also fixes issue #265 because now it plays entering audio in SystemMenu).
- Add entering audio for YES/NO buttons in SystemMessageBox.
- Add hiding audio for Help Menu.