### PR TITLE
Fix skip bug plus add missing sound to CCLCC SystemMenu.

### DIFF
--- a/src/games/cclcc/systemmenu.cpp
+++ b/src/games/cclcc/systemmenu.cpp
@@ -4,6 +4,7 @@
 #include "../../renderer/renderer.h"
 #include "../../ui/ui.h"
 #include "../../vm/interface/input.h"
+#include "../../inputsystem.h"
 #include "../../profile/ui/systemmenu.h"
 #include "../../profile/game.h"
 #include "../../ui/widgets/cclcc/sysmenubutton.h"
@@ -26,6 +27,14 @@ void SystemMenu::MenuButtonOnClick(Widgets::Button* target) {
       SaveMenuPageType::_from_integral_nothrow(target->Id % 4);
   Audio::Channels[Audio::AC_SSE]->Play("sysse", 2, false, 0);
   ChoiceMade = true;
+}
+
+void SystemMenu::UpdateInput(float dt) {
+  if (!IsFocused) return;
+  Menu::UpdateInput(dt);
+  if (PADinputButtonWentDown & (PAD1DOWN | PAD1UP)) {
+    Audio::Channels[Audio::AC_SSE]->Play("sysse", 1, false, 0);
+  }
 }
 
 SystemMenu::SystemMenu() {

--- a/src/games/cclcc/systemmenu.h
+++ b/src/games/cclcc/systemmenu.h
@@ -22,6 +22,7 @@ class SystemMenu : public Menu {
   void Init() override;
   void Show() override;
   void Hide() override;
+  void UpdateInput(float dt) override;
   void Update(float dt) override;
   void Render() override;
 

--- a/src/vm/inst_dialogue.cpp
+++ b/src/vm/inst_dialogue.cpp
@@ -669,6 +669,12 @@ VmInstruction(InstSetRevMes) {
 void ChkMesSkip() {
   bool mesSkip = false;
 
+  if (MesSkipMode & (SkipModeFlags::SkipRead | SkipModeFlags::SkipAll)) {
+    MesSkipMode &= SkipModeFlags::Auto;
+    MesSkipMode |= (Profile::ConfigSystem::SkipRead ? SkipModeFlags::SkipRead
+                                                    : SkipModeFlags::SkipAll);
+  }
+
   if (ScrWork[SW_SYSMESALPHA] != 255) MesSkipMode = false;
 
   if ((ScrWork[SW_GAMESTATE] & 0b101) == 0b001 && !GetFlag(SF_UIHIDDEN)) {


### PR DESCRIPTION
This PR will: 
- Fix skip bug (issue #267). 
- Add the missing Selection sound that plays when switching between buttons (Backlog, Save, etc.) in CCLCC System Menu using a gamepad or keyboard.