### PR TITLE
[CCLCC]Small audio adjustments.

### DIFF
--- a/src/games/cclcc/musicmenu.cpp
+++ b/src/games/cclcc/musicmenu.cpp
@@ -100,8 +100,11 @@ void MusicTrackButton::Update(float dt) {
   const int alpha = ((ScrWork[SW_SYSSUBMENUCT] * 32 - 768) * 224) >> 8;
   Tint = glm::vec4(1.0f, 1.0f, 1.0f, alpha / 255.0f);
   Button::Update(dt);
-  if (HasFocus && !PrevFocusState)
-    Audio::Channels[Audio::AC_SSE]->Play("sysse", 1, false, 0);
+  if (HasFocus && !PrevFocusState) {
+    if (Input::CurrentInputDevice != Input::Device::Mouse) {
+      Audio::Channels[Audio::AC_SSE]->Play("sysse", 1, false, 0);
+    }
+  }
   if (PrevFocusState != HasFocus) {
     PrevFocusState = HasFocus;
   }

--- a/src/ui/widgets/cclcc/titlebutton.cpp
+++ b/src/ui/widgets/cclcc/titlebutton.cpp
@@ -1,6 +1,7 @@
 #include "titlebutton.h"
 
 #include "../../../renderer/renderer.h"
+#include "../../../inputsystem.h"
 #include "../../../profile/games/cclcc/titlemenu.h"
 
 namespace Impacto {
@@ -38,7 +39,9 @@ void TitleButton::Update(float dt) {
   }
   if (PrevFocusState != HasFocus) {
     PrevFocusState = HasFocus;
-    Audio::Channels[Audio::AC_SSE]->Play("sysse", 1, false, 0);
+    if (Input::CurrentInputDevice != Input::Device::Mouse) {
+      Audio::Channels[Audio::AC_SSE]->Play("sysse", 1, false, 0);
+    }
     if (!IsSubButton) {
       if (HighlightAnimation.IsOut() && HasFocus) {
         HighlightAnimation.StartIn();


### PR DESCRIPTION
This PR will:

- Disable Selecting sound when user hovers over buttons with his mouse in CCLCC Main Menu. Sound will still play if user selects these buttons with a keyboard or gamepad, like in C;C.

- Disable Selecting sound when user hovers over track buttons (lines in the list) with his mouse in CCLCC Music Menu. Sound will still play if user selects these buttons with a keyboard or gamepad, like in C;C.