### PR TITLE
Remove extra audio when closing save menus in CCLCC

### DIFF
--- a/src/games/cclcc/savemenu.cpp
+++ b/src/games/cclcc/savemenu.cpp
@@ -213,7 +213,6 @@ void SaveMenu::Hide() {
       UI::FocusedMenu = 0;
     }
     IsFocused = false;
-    Audio::PlayInGroup(Audio::ACG_SE, "sysse", 3, false, 0);
   }
 }
 


### PR DESCRIPTION

[audio overlap.webm](https://github.com/user-attachments/assets/d5814fac-7a6e-47e2-87be-de6652d7d4ff)

[post fix.webm](https://github.com/user-attachments/assets/20aa2f71-3e7b-4c1f-af15-147ca9d075e4)
