### PR TITLE
YES/NO trigger doesn't play the sound effect on the starting animation

### DIFF
--- a/src/vm/inst_sound.cpp
+++ b/src/vm/inst_sound.cpp
@@ -63,9 +63,7 @@ VmInstruction(InstSEplay) {
       Audio::Channels[Audio::AC_SE0 + channel]->Pause();
     }
   } else {
-    ImpLogSlow(LogLevel::Warning, LogChannel::VMStub,
-               "STUB instruction SEplay(channel: {:d}, type: {:d})\n", channel,
-               type);
+    Audio::Channels[Audio::AC_SE0 + channel]->Resume();
   }
 }
 VmInstruction(InstSEplayMO6) {


### PR DESCRIPTION
Script piece where you can see pair of type2 beign called after pair of type1
<a href="https://github.com/user-attachments/assets/5587f1bc-704f-436b-a109-869ad4889477" target="_blank">
  <img src="https://github.com/user-attachments/assets/5587f1bc-704f-436b-a109-869ad4889477" width="200">
</a>

Dev proof:

https://github.com/user-attachments/assets/fdea73a5-d36c-490a-9b4b-162411e0ba71

https://github.com/user-attachments/assets/5d87ca56-ba87-41f0-bb2c-39d10a9e27ae


