### PR TITLE
Add support to window icons to SDL_Window from profiles.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ set(Impacto_Src
         src/animation.cpp
 
         src/renderer/renderer.cpp
+        src/renderer/window.cpp
 
         src/data/savesystem.cpp
         src/data/tipssystem.cpp

--- a/profiles/cc/game.lua
+++ b/profiles/cc/game.lua
@@ -6,6 +6,7 @@ root.DesignWidth = 1920;
 root.DesignHeight = 1080;
 
 root.WindowName = "CHAOS;CHILD";
+root.WindowIconPath = "profiles/cc/icon.png";
 root.UseMoviePriority = true;
 
 root.CharaIsMvl = false;

--- a/profiles/cclcc/game.lua
+++ b/profiles/cclcc/game.lua
@@ -7,6 +7,7 @@ root.DesignWidth = 1920;
 root.DesignHeight = 1080;
 
 root.WindowName = "CHAOS;CHILD Love Chu☆Chu!!";
+root.WindowIconPath = "profiles/cclcc/icon.png";
 
 root.CharaIsMvl = true;
 root.UseMoviePriority = true;

--- a/profiles/chlcc/game.lua
+++ b/profiles/chlcc/game.lua
@@ -6,6 +6,7 @@ root.DesignWidth = 1280;
 root.DesignHeight = 720;
 
 root.WindowName = "CHAOS;HEAD Love Chu☆Chu!";
+root.WindowIconPath = "profiles/chlcc/icon.png";
 
 root.CharaIsMvl = false;
 root.UseMoviePriority = true;

--- a/profiles/chn/game.lua
+++ b/profiles/chn/game.lua
@@ -6,6 +6,7 @@ root.DesignWidth = 1920;
 root.DesignHeight = 1080;
 
 root.WindowName = "CHAOS;HEAD NOAH";
+root.WindowIconPath = "profiles/chn/icon.png";
 
 root.CharaIsMvl = true;
 

--- a/profiles/darling/game.lua
+++ b/profiles/darling/game.lua
@@ -6,6 +6,7 @@ root.DesignWidth = 1280;
 root.DesignHeight = 720;
 
 root.WindowName = "STEINS;GATE: Hiyoku Renri no Darling";
+root.WindowIconPath = "profiles/darling/icon.png";
 
 root.CharaIsMvl = false;
 root.LayFileBigEndian = true;

--- a/profiles/dash/game.lua
+++ b/profiles/dash/game.lua
@@ -6,6 +6,7 @@ root.DesignWidth = 1920;
 root.DesignHeight = 1080;
 
 root.WindowName = "ROBOTICS;NOTES DaSH";
+root.WindowIconPath = "profiles/dash/icon.png";
 
 root.Vm = {
     StartScript = 4,

--- a/profiles/mo6tw/game.lua
+++ b/profiles/mo6tw/game.lua
@@ -6,6 +6,7 @@ root.DesignWidth = 1280;
 root.DesignHeight = 720;
 
 root.WindowName = "Memories Off 6 ~T-Wave~";
+root.WindowIconPath = "profiles/mo6tw/icon.png";
 
 root.CharaIsMvl = false;
 root.LayFileBigEndian = true;

--- a/profiles/mo7/game.lua
+++ b/profiles/mo7/game.lua
@@ -6,6 +6,7 @@ root.DesignWidth = 1280;
 root.DesignHeight = 720;
 
 root.WindowName = "Memories Off Yubikiri no Kioku";
+root.WindowIconPath = "profiles/mo7/icon.png";
 
 root.CharaIsMvl = false;
 root.LayFileBigEndian = true;

--- a/profiles/mo8/game.lua
+++ b/profiles/mo8/game.lua
@@ -6,6 +6,7 @@ root.DesignWidth = 1920;
 root.DesignHeight = 1080;
 
 root.WindowName = "Memories Off -Innocent Fille-";
+root.WindowIconPath = "profiles/mo8/icon.png";
 
 root.CharaIsMvl = true;
 root.UseMoviePriority = true;

--- a/profiles/rne/game.lua
+++ b/profiles/rne/game.lua
@@ -6,6 +6,7 @@ root.DesignWidth = 1280;
 root.DesignHeight = 720;
 
 root.WindowName = "ROBOTICS;NOTES ELITE";
+root.WindowIconPath = "profiles/rne/icon.png";
 
 root.Vm = {
     StartScript = 4,

--- a/profiles/sgps3/game.lua
+++ b/profiles/sgps3/game.lua
@@ -6,6 +6,7 @@ root.DesignWidth = 1280;
 root.DesignHeight = 720;
 
 root.WindowName = "STEINS;GATE";
+root.WindowIconPath = "profiles/sgps3/icon.png";
 
 root.CharaIsMvl = false;
 root.LayFileBigEndian = true;

--- a/src/profile/game.cpp
+++ b/src/profile/game.cpp
@@ -16,6 +16,7 @@ void LoadGameFromLua() {
   LayerCount = EnsureGetMember<int>("LayerCount");
   GameFeatures = EnsureGetMember<int>("GameFeatures");
   WindowName = EnsureGetMember<char const*>("WindowName");
+  WindowIconPath = TryGetMember<std::string>("WindowIconPath");
   DesignWidth = EnsureGetMember<float>("DesignWidth");
   DesignHeight = EnsureGetMember<float>("DesignHeight");
 

--- a/src/profile/game.h
+++ b/src/profile/game.h
@@ -3,6 +3,8 @@
 #include "../game.h"
 
 #include <cstdint>
+#include <optional>
+#include <string>
 
 namespace Impacto {
 namespace Profile {
@@ -15,6 +17,7 @@ inline uint32_t LayerCount;
 inline int GameFeatures;
 
 inline char const* WindowName;
+inline std::optional<std::string> WindowIconPath;
 
 inline bool LayFileBigEndian;
 inline bool CharaIsMvl;

--- a/src/renderer/dx9/window.cpp
+++ b/src/renderer/dx9/window.cpp
@@ -95,6 +95,8 @@ void DirectX9Window::Init() {
   ImpLog(LogLevel::Debug, LogChannel::General,
          "Window size (screen coords): {:d} x {:d}\n", WindowWidth,
          WindowHeight);
+
+  SetWindowIcon(SDLWindow);
 }
 
 void DirectX9Window::SetDimensions(int width, int height, int msaa,

--- a/src/renderer/opengl/window.cpp
+++ b/src/renderer/opengl/window.cpp
@@ -205,6 +205,8 @@ void GLWindow::Init() {
          "Window size (screen coords): {:d} x {:d}\n", WindowWidth,
          WindowHeight);
 
+  SetWindowIcon(SDLWindow);
+
   bool gladOk;
   if (ActualGraphicsApi == GfxApi_GL) {
     gladOk = gladLoadGLLoader(SDL_GL_GetProcAddress);

--- a/src/renderer/vulkan/window.cpp
+++ b/src/renderer/vulkan/window.cpp
@@ -92,6 +92,8 @@ void VulkanWindow::Init() {
   ImpLog(LogLevel::Debug, LogChannel::General,
          "Window size (screen coords): {:d} x {:d}\n", WindowWidth,
          WindowHeight);
+
+  SetWindowIcon(SDLWindow);
 }
 
 void VulkanWindow::SetDimensions(int width, int height, int msaa,

--- a/src/renderer/window.cpp
+++ b/src/renderer/window.cpp
@@ -1,0 +1,66 @@
+#include "window.h"
+#include "../io/assetpath.h"
+#include "../profile/game.h"
+#include "../log.h"
+#include <stb_image.h>
+#include <memory>
+#include <vector>
+
+namespace Impacto {
+
+void SetWindowIcon(SDL_Window* window) {
+  if (!Profile::WindowIconPath.has_value()) {
+    return;
+  }
+
+  Io::AssetPath asset;
+  asset.FileName = Profile::WindowIconPath->c_str();
+  Io::Stream* streamPtr;
+  IoError err = asset.Open(&streamPtr);
+  if (err != IoError_OK) {
+    ImpLog(LogLevel::Warning, LogChannel::General,
+           "Could not open window icon file {:s}\n",
+           Profile::WindowIconPath->c_str());
+    return;
+  }
+  std::unique_ptr<Io::Stream> stream(streamPtr);
+  size_t fileSize = stream->Meta.Size;
+  std::vector<uint8_t> fileData(fileSize);
+  int64_t bytesRead = stream->Read(fileData.data(), fileSize);
+
+  if (bytesRead != (int64_t)fileSize) {
+    ImpLog(LogLevel::Warning, LogChannel::General,
+           "Could not read window icon file {:s}\n",
+           Profile::WindowIconPath->c_str());
+    return;
+  }
+
+  int width, height, channels;
+  uint8_t* image =
+      stbi_load_from_memory((const stbi_uc*)fileData.data(), (int)fileSize,
+                            &width, &height, &channels, STBI_rgb_alpha);
+
+  if (!image) {
+    ImpLog(LogLevel::Warning, LogChannel::General,
+           "Could not load window icon from {:s}\n",
+           Profile::WindowIconPath->c_str());
+    return;
+  }
+
+  SDL_Surface* surface =
+      SDL_CreateRGBSurfaceFrom(image, width, height, 32, width * 4, 0x000000FF,
+                               0x0000FF00, 0x00FF0000, 0xFF000000);
+  if (!surface) {
+    ImpLog(LogLevel::Error, LogChannel::General,
+           "Could not create SDL surface for window icon from {:s}: {:s}\n",
+           Profile::WindowIconPath->c_str(), SDL_GetError());
+    stbi_image_free(image);
+    return;
+  }
+
+  SDL_SetWindowIcon(window, surface);
+  SDL_FreeSurface(surface);
+  stbi_image_free(image);
+}
+
+}  // namespace Impacto

--- a/src/renderer/window.h
+++ b/src/renderer/window.h
@@ -5,6 +5,8 @@
 
 namespace Impacto {
 
+void SetWindowIcon(SDL_Window* window);
+
 enum GraphicsApi {
   GfxApi_GL,
   // Forces the use of a GLES driver (e.g. ANGLE on Windows)


### PR DESCRIPTION
This PR will add support to window icons to SDL_Window from profiles. (issue #219). You will need to add icons files (standard .png or .jpg and etc.), because I only added support to them.

Example:
<img width="213" height="27" alt="{96D934EF-CD8A-4BEA-A14B-DAECB7CC5955}" src="https://github.com/user-attachments/assets/541e98a8-5891-4618-badd-077b4416be3a" />
