### PR TITLE
Lock "Save" button if SF_SAVEDISABLE is set

### DIFF
--- a/src/games/cclcc/systemmenu.cpp
+++ b/src/games/cclcc/systemmenu.cpp
@@ -172,13 +172,17 @@ void SystemMenu::Update(float dt) {
       }
     }
 
+    bool savesDisabled = GetFlag(SF_SAVEDISABLE);
     bool noFreeSlots = SaveSystem::MaxSaveEntries ==
                        SaveSystem::Implementation->GetLockedQuickSaveCount();
-    bool quickSaveLockState = GetFlag(SF_SAVEDISABLE) || noFreeSlots ||
-                              SaveSystem::HasQSavedOnCurrentLine();
+    bool quickSaveLockState =
+        savesDisabled || noFreeSlots || SaveSystem::HasQSavedOnCurrentLine();
     static_cast<UI::CCLCC::SysMenuButton*>(
         MainItems->Children[static_cast<size_t>(MenuItems::QuickSave)])
         ->IsLocked = quickSaveLockState;
+    static_cast<UI::CCLCC::SysMenuButton*>(
+        MainItems->Children[static_cast<size_t>(MenuItems::Save)])
+        ->IsLocked = savesDisabled;
   }
 
   if (State == Shown && IsFocused) {

--- a/src/games/chlcc/systemmenu.cpp
+++ b/src/games/chlcc/systemmenu.cpp
@@ -142,14 +142,18 @@ void SystemMenu::Update(float dt) {
 
     UpdateMenuLoop();
     UpdateTitles();
+
+    bool savesDisabled = GetFlag(SF_SAVEDISABLE);
     bool noFreeSlots = SaveSystem::MaxSaveEntries ==
                        SaveSystem::Implementation->GetLockedQuickSaveCount();
-    bool quickSaveLockState = GetFlag(SF_SAVEDISABLE) ||
-                              SaveSystem::HasQSavedOnCurrentLine() ||
-                              noFreeSlots;
+    bool quickSaveLockState =
+        savesDisabled || SaveSystem::HasQSavedOnCurrentLine() || noFreeSlots;
     static_cast<SystemMenuEntryButton*>(
         MainItems->Children[static_cast<size_t>(MenuItems::QuickSave)])
         ->IsLocked = quickSaveLockState;
+    static_cast<SystemMenuEntryButton*>(
+        MainItems->Children[static_cast<size_t>(MenuItems::Save)])
+        ->IsLocked = savesDisabled;
   }
 
   auto* btn = static_cast<Widgets::Button*>(CurrentlyFocusedElement);


### PR DESCRIPTION
C;CLCC For example during YES/NO triggers
Added support for this in C;HLCC cause seen it being set/reset somewhere in the scripts