### PR TITLE
Add custom arrow and pointer icons per game support.

### DIFF
--- a/profiles/cc/game.lua
+++ b/profiles/cc/game.lua
@@ -7,6 +7,8 @@ root.DesignHeight = 1080;
 
 root.WindowName = "CHAOS;CHILD";
 root.WindowIconPath = "profiles/cc/icon.png";
+root.CursorArrowPath = "profiles/cc/cursor_arrow.png";
+root.CursorPointerPath = "profiles/cc/cursor_pointer.png";
 root.UseMoviePriority = true;
 
 root.CharaIsMvl = false;

--- a/profiles/cclcc/game.lua
+++ b/profiles/cclcc/game.lua
@@ -8,6 +8,8 @@ root.DesignHeight = 1080;
 
 root.WindowName = "CHAOS;CHILD Love Chu☆Chu!!";
 root.WindowIconPath = "profiles/cclcc/icon.png";
+root.CursorArrowPath = "profiles/cclcc/cursor_arrow.png";
+root.CursorPointerPath = "profiles/cclcc/cursor_pointer.png";
 
 root.CharaIsMvl = true;
 root.UseMoviePriority = true;

--- a/profiles/chlcc/game.lua
+++ b/profiles/chlcc/game.lua
@@ -7,6 +7,8 @@ root.DesignHeight = 720;
 
 root.WindowName = "CHAOS;HEAD Love Chu☆Chu!";
 root.WindowIconPath = "profiles/chlcc/icon.png";
+root.CursorArrowPath = "profiles/chlcc/cursor_arrow.png";
+root.CursorPointerPath = "profiles/chlcc/cursor_pointer.png";
 
 root.CharaIsMvl = false;
 root.UseMoviePriority = true;

--- a/profiles/chn/game.lua
+++ b/profiles/chn/game.lua
@@ -7,6 +7,8 @@ root.DesignHeight = 1080;
 
 root.WindowName = "CHAOS;HEAD NOAH";
 root.WindowIconPath = "profiles/chn/icon.png";
+root.CursorArrowPath = "profiles/chn/cursor_arrow.png";
+root.CursorPointerPath = "profiles/chn/cursor_pointer.png";
 
 root.CharaIsMvl = true;
 

--- a/profiles/darling/game.lua
+++ b/profiles/darling/game.lua
@@ -7,6 +7,8 @@ root.DesignHeight = 720;
 
 root.WindowName = "STEINS;GATE: Hiyoku Renri no Darling";
 root.WindowIconPath = "profiles/darling/icon.png";
+root.CursorArrowPath = "profiles/darling/cursor_arrow.png";
+root.CursorPointerPath = "profiles/darling/cursor_pointer.png";
 
 root.CharaIsMvl = false;
 root.LayFileBigEndian = true;

--- a/profiles/dash/game.lua
+++ b/profiles/dash/game.lua
@@ -7,6 +7,8 @@ root.DesignHeight = 1080;
 
 root.WindowName = "ROBOTICS;NOTES DaSH";
 root.WindowIconPath = "profiles/dash/icon.png";
+root.CursorArrowPath = "profiles/dash/cursor_arrow.png";
+root.CursorPointerPath = "profiles/dash/cursor_pointer.png";
 
 root.Vm = {
     StartScript = 4,

--- a/profiles/mo6tw/game.lua
+++ b/profiles/mo6tw/game.lua
@@ -7,6 +7,8 @@ root.DesignHeight = 720;
 
 root.WindowName = "Memories Off 6 ~T-Wave~";
 root.WindowIconPath = "profiles/mo6tw/icon.png";
+root.CursorArrowPath = "profiles/mo6tw/cursor_arrow.png";
+root.CursorPointerPath = "profiles/mo6tw/cursor_pointer.png";
 
 root.CharaIsMvl = false;
 root.LayFileBigEndian = true;

--- a/profiles/mo7/game.lua
+++ b/profiles/mo7/game.lua
@@ -7,6 +7,8 @@ root.DesignHeight = 720;
 
 root.WindowName = "Memories Off Yubikiri no Kioku";
 root.WindowIconPath = "profiles/mo7/icon.png";
+root.CursorArrowPath = "profiles/mo7/cursor_arrow.png";
+root.CursorPointerPath = "profiles/mo7/cursor_pointer.png";
 
 root.CharaIsMvl = false;
 root.LayFileBigEndian = true;

--- a/profiles/mo8/game.lua
+++ b/profiles/mo8/game.lua
@@ -7,6 +7,8 @@ root.DesignHeight = 1080;
 
 root.WindowName = "Memories Off -Innocent Fille-";
 root.WindowIconPath = "profiles/mo8/icon.png";
+root.CursorArrowPath = "profiles/mo8/cursor_arrow.png";
+root.CursorPointerPath = "profiles/mo8/cursor_pointer.png";
 
 root.CharaIsMvl = true;
 root.UseMoviePriority = true;

--- a/profiles/rne/game.lua
+++ b/profiles/rne/game.lua
@@ -7,6 +7,8 @@ root.DesignHeight = 720;
 
 root.WindowName = "ROBOTICS;NOTES ELITE";
 root.WindowIconPath = "profiles/rne/icon.png";
+root.CursorArrowPath = "profiles/rne/cursor_arrow.png";
+root.CursorPointerPath = "profiles/rne/cursor_pointer.png";
 
 root.Vm = {
     StartScript = 4,

--- a/profiles/sgps3/game.lua
+++ b/profiles/sgps3/game.lua
@@ -7,6 +7,8 @@ root.DesignHeight = 720;
 
 root.WindowName = "STEINS;GATE";
 root.WindowIconPath = "profiles/sgps3/icon.png";
+root.CursorArrowPath = "profiles/sgps3/cursor_arrow.png";
+root.CursorPointerPath = "profiles/sgps3/cursor_pointer.png";
 
 root.CharaIsMvl = false;
 root.LayFileBigEndian = true;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -22,6 +22,7 @@
 #include "mem.h"
 #include "vm/interface/input.h"
 #include "vm/inst_dialogue.h"
+#include "renderer/window.h"
 #include "hud/datedisplay.h"
 #include "hud/saveicondisplay.h"
 #include "hud/loadingdisplay.h"
@@ -83,6 +84,7 @@ static void Init() {
 #endif
 
   InitRenderer();
+  InitCursors();
 
   memset(DrawComponents, DrawComponentType::None, sizeof(DrawComponents));
 
@@ -215,6 +217,7 @@ void UpdateSystem(float dt) {
   SDL_Event e;
   if (Profile::GameFeatures & GameFeature::Input) {
     Input::BeginFrame();
+    RequestCursor(CursorType::Default);
   }
 
   while (SDL_PollEvent(&e)) {
@@ -265,6 +268,8 @@ void UpdateSystem(float dt) {
     }
 
     Vm::Update(dt);
+
+    ApplyCursorForFrame();
   }
   UpdateSecondCounter = 0.0f;
 }

--- a/src/profile/game.cpp
+++ b/src/profile/game.cpp
@@ -17,6 +17,8 @@ void LoadGameFromLua() {
   GameFeatures = EnsureGetMember<int>("GameFeatures");
   WindowName = EnsureGetMember<char const*>("WindowName");
   WindowIconPath = TryGetMember<std::string>("WindowIconPath");
+  CursorArrowPath = TryGetMember<std::string>("CursorArrowPath");
+  CursorPointerPath = TryGetMember<std::string>("CursorPointerPath");
   DesignWidth = EnsureGetMember<float>("DesignWidth");
   DesignHeight = EnsureGetMember<float>("DesignHeight");
 

--- a/src/profile/game.h
+++ b/src/profile/game.h
@@ -18,6 +18,8 @@ inline int GameFeatures;
 
 inline char const* WindowName;
 inline std::optional<std::string> WindowIconPath;
+inline std::optional<std::string> CursorArrowPath;
+inline std::optional<std::string> CursorPointerPath;
 
 inline bool LayFileBigEndian;
 inline bool CharaIsMvl;

--- a/src/renderer/window.cpp
+++ b/src/renderer/window.cpp
@@ -5,6 +5,8 @@
 #include <stb_image.h>
 #include <memory>
 #include <vector>
+#include <optional>
+#include "../inputsystem.h"
 
 namespace Impacto {
 
@@ -61,6 +63,142 @@ void SetWindowIcon(SDL_Window* window) {
   SDL_SetWindowIcon(window, surface);
   SDL_FreeSurface(surface);
   stbi_image_free(image);
+}
+
+static SDL_Cursor* CursorArrow = nullptr;
+static SDL_Cursor* CursorPointer = nullptr;
+static SDL_Cursor* CurrentCursor = nullptr;
+static std::optional<CursorType> RequestedCursorType;
+static Input::Device PreviousInputDevice = Input::Device::Mouse;
+
+static SDL_Cursor* LoadCursorFromFile(const std::string& path) {
+  Io::AssetPath asset;
+  asset.FileName = path.c_str();
+  Io::Stream* streamPtr;
+  IoError err = asset.Open(&streamPtr);
+  if (err != IoError_OK) {
+    ImpLog(LogLevel::Warning, LogChannel::General,
+           "Could not open cursor file {:s}\n", path.c_str());
+    return nullptr;
+  }
+  std::unique_ptr<Io::Stream> stream(streamPtr);
+  size_t fileSize = stream->Meta.Size;
+  std::vector<uint8_t> fileData(fileSize);
+  int64_t bytesRead = stream->Read(fileData.data(), fileSize);
+  if (bytesRead != (int64_t)fileSize) {
+    ImpLog(LogLevel::Warning, LogChannel::General,
+           "Could not read cursor file {:s}\n", path.c_str());
+    return nullptr;
+  }
+
+  int width, height, channels;
+  uint8_t* image =
+      stbi_load_from_memory((const stbi_uc*)fileData.data(), (int)fileSize,
+                            &width, &height, &channels, STBI_rgb_alpha);
+  if (!image) {
+    ImpLog(LogLevel::Warning, LogChannel::General,
+           "Could not load cursor image from {:s}\n", path.c_str());
+    return nullptr;
+  }
+
+  SDL_Surface* surface =
+      SDL_CreateRGBSurfaceFrom(image, width, height, 32, width * 4, 0x000000FF,
+                               0x0000FF00, 0x00FF0000, 0xFF000000);
+  if (!surface) {
+    ImpLog(LogLevel::Error, LogChannel::General,
+           "Could not create SDL surface for cursor from {:s}: {:s}\n",
+           path.c_str(), SDL_GetError());
+    stbi_image_free(image);
+    return nullptr;
+  }
+
+  SDL_Cursor* cursor = SDL_CreateColorCursor(surface, 0, 0);
+  if (!cursor) {
+    ImpLog(LogLevel::Error, LogChannel::General,
+           "SDL_CreateColorCursor failed for {:s}: {:s}\n", path.c_str(),
+           SDL_GetError());
+  }
+
+  SDL_FreeSurface(surface);
+  stbi_image_free(image);
+  return cursor;
+}
+
+void InitCursors() {
+  if (Profile::CursorArrowPath.has_value()) {
+    CursorArrow = LoadCursorFromFile(*Profile::CursorArrowPath);
+  }
+  if (!CursorArrow) {
+    CursorArrow = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_ARROW);
+  }
+
+  if (Profile::CursorPointerPath.has_value()) {
+    CursorPointer = LoadCursorFromFile(*Profile::CursorPointerPath);
+  }
+  if (!CursorPointer) {
+    CursorPointer = SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_HAND);
+  }
+
+  if (CursorArrow) {
+    SDL_SetCursor(CursorArrow);
+    CurrentCursor = CursorArrow;
+  }
+}
+
+void RequestCursor(CursorType type) {
+  if (Input::CurrentInputDevice == Input::Device::Mouse) {
+    if (type == CursorType::Pointer && CursorPointer) {
+      if (CurrentCursor != CursorPointer) {
+        RequestedCursorType = CursorType::Pointer;
+      } else {
+        RequestedCursorType = std::nullopt;
+      }
+    } else {
+      if (CurrentCursor != CursorArrow) {
+        RequestedCursorType = CursorType::Default;
+      } else {
+        RequestedCursorType = std::nullopt;
+      }
+    }
+  }
+}
+
+void ApplyCursorForFrame() {
+  SDL_Cursor* actualCursor = SDL_GetCursor();
+
+  if (Input::CurrentInputDevice != PreviousInputDevice) {
+    CurrentCursor = actualCursor;
+    PreviousInputDevice = Input::CurrentInputDevice;
+  }
+
+  SDL_Cursor* desired = CursorArrow;
+
+  if (Input::CurrentInputDevice == Input::Device::Mouse) {
+    if (RequestedCursorType.has_value()) {
+      if (*RequestedCursorType == CursorType::Pointer && CursorPointer) {
+        desired = CursorPointer;
+      } else if (*RequestedCursorType == CursorType::Default) {
+        desired = CursorArrow;
+      }
+      RequestedCursorType = std::nullopt;
+    } else {
+      if (actualCursor != CursorArrow && actualCursor != CursorPointer) {
+        desired = CursorArrow;
+      } else {
+        desired = actualCursor;
+      }
+    }
+  } else {
+    RequestedCursorType = std::nullopt;
+    desired = CursorArrow;
+  }
+
+  if (desired && desired != actualCursor) {
+    SDL_SetCursor(desired);
+    CurrentCursor = desired;
+  } else {
+    CurrentCursor = actualCursor;
+  }
 }
 
 }  // namespace Impacto

--- a/src/renderer/window.h
+++ b/src/renderer/window.h
@@ -5,7 +5,12 @@
 
 namespace Impacto {
 
+enum class CursorType { Default, Pointer };
+
 void SetWindowIcon(SDL_Window* window);
+void InitCursors();
+void RequestCursor(CursorType type);
+void ApplyCursorForFrame();
 
 enum GraphicsApi {
   GfxApi_GL,

--- a/src/ui/widget.cpp
+++ b/src/ui/widget.cpp
@@ -1,4 +1,6 @@
 #include "widget.h"
+#include "../inputsystem.h"
+#include "../renderer/window.h"
 
 namespace Impacto {
 namespace UI {
@@ -7,6 +9,10 @@ void Widget::Update(float dt) {
     MoveAnimation.Update(dt);
     auto move = glm::mix(MoveOrigin, MoveTarget, MoveAnimation.Progress);
     MoveTo(move);
+  }
+
+  if (Enabled && Hovered && Input::CurrentInputDevice == Input::Device::Mouse) {
+    RequestCursor(CursorType::Pointer);
   }
 }
 

--- a/src/ui/widgets/cclcc/titlebutton.cpp
+++ b/src/ui/widgets/cclcc/titlebutton.cpp
@@ -29,6 +29,7 @@ void TitleButton::UpdateInput(float dt) {
 }
 
 void TitleButton::Update(float dt) {
+  Widget::Update(dt);
   HighlightAnimation.Update(dt);
   ChoiceBlinkAnimation.Update(dt);
   if (ChoiceBlinkAnimation.IsIn()) {

--- a/src/ui/widgets/scrollbar.cpp
+++ b/src/ui/widgets/scrollbar.cpp
@@ -2,6 +2,7 @@
 #include "../../renderer/renderer.h"
 #include "../../inputsystem.h"
 #include "../../vm/interface/input.h"
+#include "../../renderer/window.h"
 
 namespace Impacto {
 namespace UI {
@@ -194,7 +195,15 @@ void Scrollbar::ClampValue() {
   *Value = std::clamp(*Value, minValue, maxValue);
 }
 
-void Scrollbar::Update(float dt) { UpdatePosition(); }
+void Scrollbar::Update(float dt) {
+  Widget::Update(dt);
+  UpdatePosition();
+
+  if (Enabled && HoveredWheelBounds &&
+      Input::CurrentInputDevice == Input::Device::Mouse) {
+    RequestCursor(CursorType::Pointer);
+  }
+}
 
 void Scrollbar::UpdatePosition() {
   TrackProgress = ((*Value - StartValue) / (EndValue - StartValue)) * Length;


### PR DESCRIPTION
This PR will add custom arrow and pointer icons per game support and will implement pointer logic when hovering clickable things. (issue #220) Custom arrow and pointer icons will use .png, or .jpg and etc. files formats.

Examples:
<img width="966" height="516" alt="{3898A843-F389-4FC5-BAEE-5B4D550FF74F}" src="https://github.com/user-attachments/assets/23bd62eb-c9a0-4372-aaa0-0c5503adfe9a" />
<img width="632" height="79" alt="{1A1587DD-32FD-4598-AF54-7C072DCAC93F}" src="https://github.com/user-attachments/assets/d24a3e8f-6005-429c-8370-1a600132dd82" />
