### PR TITLE
[CCLCC][CHLCC] Bug fixes.

### DIFF
--- a/src/games/cc/titlemenu.cpp
+++ b/src/games/cc/titlemenu.cpp
@@ -34,17 +34,20 @@ using namespace Impacto::Vm::Interface;
 using namespace Impacto::UI::Widgets::CC;
 
 void TitleMenu::MenuButtonOnClick(Widgets::Button* target) {
+  target->Hovered = false;
   ScrWork[SW_TITLECUR1] = target->Id;
   SetFlag(SF_TITLEEND, 1);
   AllowsScriptInput = true;
 }
 
 void TitleMenu::ContinueButtonOnClick(Widgets::Button* target) {
+  target->Hovered = false;
   CurrentSubMenu = ContinueItems;
   AllowsScriptInput = false;
 }
 
 void TitleMenu::ExtraButtonOnClick(Widgets::Button* target) {
+  target->Hovered = false;
   CurrentSubMenu = ExtraItems;
   AllowsScriptInput = false;
 }

--- a/src/games/cclcc/savemenu.cpp
+++ b/src/games/cclcc/savemenu.cpp
@@ -24,6 +24,7 @@ using namespace Impacto::UI::Widgets::CCLCC;
 Widget* EntryGrid[Pages][RowsPerPage][EntriesPerRow];
 
 void SaveMenu::MenuButtonOnClick(Widgets::Button* target) {
+  target->Hovered = false;
   Impacto::SaveSystem::SaveType saveType =
       *ActiveMenuType == +SaveMenuPageType::QuickLoad
           ? SaveSystem::SaveType::Quick

--- a/src/games/cclcc/systemmenu.cpp
+++ b/src/games/cclcc/systemmenu.cpp
@@ -20,6 +20,7 @@ using namespace Impacto::Profile::SystemMenu;
 using namespace Impacto::UI::Widgets::CCLCC;
 
 void SystemMenu::MenuButtonOnClick(Widgets::Button* target) {
+  target->Hovered = false;
   bool targetButtonLocked = static_cast<SysMenuButton*>(target)->IsLocked;
   Audio::PlayInGroup(Audio::ACG_SE, "sysse", targetButtonLocked ? 4 : 2, false,
                      0);
@@ -107,6 +108,7 @@ void SystemMenu::Show() {
       UI::FocusedMenu = this;
       ItemsFade.StartIn();
       MainItems->Show();
+      if (!CurrentlyFocusedElement) AdvanceFocus(FDIR_DOWN);
     }
   }
 }

--- a/src/games/cclcc/titlemenu.cpp
+++ b/src/games/cclcc/titlemenu.cpp
@@ -28,6 +28,7 @@ using namespace Impacto::Vm::Interface;
 using namespace Impacto::UI::Widgets::CCLCC;
 
 void TitleMenu::MenuButtonOnClick(Widgets::Button* target) {
+  target->Hovered = false;
   TitleButton* button = static_cast<TitleButton*>(target);
   Audio::PlayInGroup(Audio::ACG_SE, "sysse", 2, false, 0);
   button->ChoiceBlinkAnimation.StartIn();
@@ -36,6 +37,7 @@ void TitleMenu::MenuButtonOnClick(Widgets::Button* target) {
 }
 
 void TitleMenu::ContinueButtonOnClick(Widgets::Button* target) {
+  target->Hovered = false;
   if (CurrentSubMenu == ContinueItems) return;
   Audio::PlayInGroup(Audio::ACG_SE, "sysse", 2, false, 0);
   CurrentSubMenu = ContinueItems;
@@ -46,6 +48,7 @@ void TitleMenu::ContinueButtonOnClick(Widgets::Button* target) {
 }
 
 void TitleMenu::ExtraButtonOnClick(Widgets::Button* target) {
+  target->Hovered = false;
   if (CurrentSubMenu == ExtraItems) return;
   // SetFlag(SF_CLR_FLAG, true); // Uncomment for testing
   if (!GetFlag(SF_CLR_FLAG)) {

--- a/src/games/chlcc/savemenu.cpp
+++ b/src/games/chlcc/savemenu.cpp
@@ -27,6 +27,7 @@ using namespace Impacto::UI::Widgets::CHLCC;
 Widget* EntryGrid[EntriesPerPage];
 
 void SaveMenu::MenuButtonOnClick(Widgets::Button* target) {
+  target->Hovered = false;
   if ((SaveSystem::GetSaveStatus(EntryType, target->Id) == 1) ||
       *ActiveMenuType == +SaveMenuPageType::Save) {
     ScrWork[SW_SAVEFILENO] = target->Id;

--- a/src/games/chlcc/systemmenu.cpp
+++ b/src/games/chlcc/systemmenu.cpp
@@ -18,6 +18,7 @@ using namespace Impacto::Profile::SystemMenu;
 using namespace Impacto::UI::Widgets::CHLCC;
 
 void SystemMenu::MenuButtonOnClick(Widgets::Button* target) {
+  target->Hovered = false;
   if (static_cast<SystemMenuEntryButton*>(target)->IsLocked) {
     // Yep, that's similar to how it's done in the binary
     // Binary checks for button state and if it's locked, PADone is modified

--- a/src/games/chlcc/titlemenu.cpp
+++ b/src/games/chlcc/titlemenu.cpp
@@ -24,11 +24,13 @@ using namespace Impacto::Profile;
 using namespace Impacto::UI::Widgets::CHLCC;
 
 void TitleMenu::MenuButtonOnClick(Widgets::Button* target) {
+  target->Hovered = false;
   ScrWork[SW_TITLECUR1] = target->Id;
   ChoiceMade = true;
 }
 
 void TitleMenu::SecondaryButtonOnClick(Widgets::Button* target) {
+  target->Hovered = false;
   ScrWork[SW_TITLECUR2] = target->Id;
   ChoiceMade = true;
 }

--- a/src/games/mo6tw/savemenu.cpp
+++ b/src/games/mo6tw/savemenu.cpp
@@ -24,6 +24,7 @@ using namespace Impacto::UI::Widgets::MO6TW;
 Widget* EntryGrid[RowsPerPage][EntriesPerRow];
 
 void SaveMenu::MenuButtonOnClick(Widgets::Button* target) {
+  target->Hovered = false;
   const SaveSystem::SaveType saveType =
       *ActiveMenuType == +SaveMenuPageType::QuickLoad
           ? SaveSystem::SaveType::Quick

--- a/src/games/mo6tw/systemmenu.cpp
+++ b/src/games/mo6tw/systemmenu.cpp
@@ -19,6 +19,7 @@ using namespace Impacto::Profile::ScriptVars;
 using namespace Impacto::UI::Widgets;
 
 void SystemMenu::MenuButtonOnClick(Widgets::Button* target) {
+  target->Hovered = false;
   ScrWork[SW_SYSMENUCNO] = target->Id;
   ChoiceMade = true;
 }

--- a/src/games/mo6tw/titlemenu.cpp
+++ b/src/games/mo6tw/titlemenu.cpp
@@ -21,11 +21,13 @@ using namespace Impacto::Profile::ScriptVars;
 using namespace Impacto::UI::Widgets::MO6TW;
 
 void TitleMenu::MenuButtonOnClick(Widgets::Button* target) {
+  target->Hovered = false;
   ScrWork[SW_TITLECUR1] = target->Id;
   ChoiceMade = true;
 }
 
 void TitleMenu::SecondaryButtonOnClick(Widgets::Button* target) {
+  target->Hovered = false;
   ScrWork[SW_TITLECUR2] = target->Id;
   ChoiceMade = true;
 }

--- a/src/games/mo8/savemenu.cpp
+++ b/src/games/mo8/savemenu.cpp
@@ -25,6 +25,7 @@ using namespace Impacto::UI::Widgets;
 Widget* EntryGrid[RowsPerPage][EntriesPerRow];
 
 void SaveMenu::MenuButtonOnClick(Widgets::Button* target) {
+  target->Hovered = false;
   if ((SaveSystem::GetSaveStatus(SaveSystem::SaveType::Full, target->Id) !=
        0) ||
       ScrWork[SW_SYSSUBMENUNO] == 4) {

--- a/src/games/mo8/systemmenu.cpp
+++ b/src/games/mo8/systemmenu.cpp
@@ -19,6 +19,7 @@ using namespace Impacto::Profile::ScriptVars;
 using namespace Impacto::UI::Widgets;
 
 void SystemMenu::MenuButtonOnClick(Widgets::Button* target) {
+  target->Hovered = false;
   ScrWork[SW_SYSMENUCNO] = target->Id;
   ChoiceMade = true;
   // When exiting through a menu button remove focus from the menu to avoid

--- a/src/games/mo8/titlemenu.cpp
+++ b/src/games/mo8/titlemenu.cpp
@@ -26,6 +26,7 @@ using namespace Impacto::Profile::ScriptVars;
 using namespace Impacto::UI::Widgets;
 
 void TitleMenu::MenuButtonOnClick(Widgets::Button* target) {
+  target->Hovered = false;
   AllowsScriptInput = true;
   ScrWork[SW_TITLECUR] = target->Id;
   SetFlag(SF_TITLEEND, 1);
@@ -33,12 +34,14 @@ void TitleMenu::MenuButtonOnClick(Widgets::Button* target) {
 }
 
 void TitleMenu::ContinueButtonOnClick(Widgets::Button* target) {
+  target->Hovered = false;
   ContinueSelected = true;
   AllowsScriptInput = false;
   Audio::PlayInGroup(Audio::ACG_SE, "sysse", 5, false, 0.0f);
 }
 
 void TitleMenu::GalleryButtonOnClick(Widgets::Button* target) {
+  target->Hovered = false;
   GallerySelected = true;
   AllowsScriptInput = false;
   Audio::PlayInGroup(Audio::ACG_SE, "sysse", 5, false, 0.0f);

--- a/src/games/rne/systemmenu.cpp
+++ b/src/games/rne/systemmenu.cpp
@@ -22,6 +22,7 @@ using namespace Impacto::UI::Widgets;
 using namespace Impacto::UI::Widgets::RNE;
 
 void SystemMenu::MenuButtonOnClick(Widgets::Button* target) {
+  target->Hovered = false;
   ScrWork[SW_SYSMENUCNO] = target->Id;
   ChoiceMade = true;
 }


### PR DESCRIPTION
This PR will:

- Fix bug where clicking a button with mouse after returning from a submenu would activate it (button, for example, Load button in CCLCC Title Menu and etc.) even if the mouse wasn't hovering button.