### PR TITLE
Fix submenus from system menu holding before closing

### DIFF
--- a/src/games/chlcc/backlogmenu.cpp
+++ b/src/games/chlcc/backlogmenu.cpp
@@ -150,21 +150,25 @@ void BacklogMenu::Render() {
 }
 
 void BacklogMenu::Update(float dt) {
-  if ((!GetFlag(SF_BACKLOGMENU) || ScrWork[SW_SYSMENUCT] < 10000) &&
+  const int sysMenuCt = ScrWork[SW_SYSMENUCT];
+  const int systemMenuCHG = ScrWork[SW_SYSTEMMENUCHG];
+
+  if ((!GetFlag(SF_BACKLOGMENU) || sysMenuCt < 10000 ||
+       (sysMenuCt == 10000 && systemMenuCHG != 0 && systemMenuCHG != 64)) &&
       State == Shown) {
     Hide();
-  } else if (GetFlag(SF_BACKLOGMENU) && ScrWork[SW_SYSMENUCT] > 0 &&
-             State == Hidden) {
+  } else if (GetFlag(SF_BACKLOGMENU) && sysMenuCt > 0 && State == Hidden) {
     Show();
   }
 
-  if (MenuTransition.IsOut() &&
-      (ScrWork[SW_SYSMENUCT] == 0 || GetFlag(SF_SYSTEMMENU)) &&
+  if (MenuTransition.IsOut() && !GetFlag(SF_BACKLOGMENU) &&
+      systemMenuCHG == 0 && (sysMenuCt == 0 || GetFlag(SF_SYSTEMMENU)) &&
       State == Hiding) {
     State = Hidden;
     MainItems->Hide();
-  } else if (MenuTransition.IsIn() && ScrWork[SW_SYSMENUCT] == 10000 &&
-             State == Showing) {
+  } else if (MenuTransition.IsIn() && sysMenuCt == 10000 &&
+             (systemMenuCHG == 0 || systemMenuCHG == 64) &&
+             GetFlag(SF_BACKLOGMENU) && State == Showing) {
     State = Shown;
     MainItems->HasFocus = true;
   }

--- a/src/games/chlcc/optionsmenu.cpp
+++ b/src/games/chlcc/optionsmenu.cpp
@@ -351,19 +351,22 @@ void OptionsMenu::UpdatePageInput(float dt) {
 }
 
 void OptionsMenu::UpdateVisibility() {
-  if ((!GetFlag(SF_OPTIONMENU) || ScrWork[SW_SYSMENUCT] < 10000) &&
+  const int sysMenuCt = ScrWork[SW_SYSMENUCT];
+  const int systemMenuCHG = ScrWork[SW_SYSTEMMENUCHG];
+
+  if ((!GetFlag(SF_OPTIONMENU) || sysMenuCt < 10000 ||
+       (sysMenuCt == 10000 && systemMenuCHG != 0 && systemMenuCHG != 64)) &&
       State == Shown) {
     Hide();
-  } else if (GetFlag(SF_OPTIONMENU) && ScrWork[SW_SYSMENUCT] > 0 &&
-             State == Hidden) {
+  } else if (GetFlag(SF_OPTIONMENU) && sysMenuCt > 0 && State == Hidden) {
     Show();
   }
 
-  if (FadeAnimation.IsOut() && !GetFlag(SF_OPTIONMENU) &&
-      (ScrWork[SW_SYSMENUCT] == 0 || GetFlag(SF_SYSTEMMENU)) &&
-      State == Hiding) {
+  if (FadeAnimation.IsOut() && !GetFlag(SF_OPTIONMENU) && systemMenuCHG == 0 &&
+      (sysMenuCt == 0 || GetFlag(SF_SYSTEMMENU)) && State == Hiding) {
     State = Hidden;
-  } else if (FadeAnimation.IsIn() && ScrWork[SW_SYSMENUCT] == 10000 &&
+  } else if (FadeAnimation.IsIn() && sysMenuCt == 10000 &&
+             (systemMenuCHG == 0 || systemMenuCHG == 64) &&
              GetFlag(SF_OPTIONMENU) && State == Showing) {
     State = Shown;
   }

--- a/src/games/chlcc/savemenu.cpp
+++ b/src/games/chlcc/savemenu.cpp
@@ -298,21 +298,24 @@ void SaveMenu::UpdateInput(float dt) {
 }
 
 void SaveMenu::Update(float dt) {
-  if ((!GetFlag(SF_SAVEMENU) || ScrWork[SW_SYSMENUCT] < 10000) &&
+  const int sysMenuCt = ScrWork[SW_SYSMENUCT];
+  const int systemMenuCHG = ScrWork[SW_SYSTEMMENUCHG];
+
+  if ((!GetFlag(SF_SAVEMENU) || sysMenuCt < 10000 ||
+       (sysMenuCt == 10000 && systemMenuCHG != 0 && systemMenuCHG != 64)) &&
       State == Shown) {
     Hide();
-  } else if (GetFlag(SF_SAVEMENU) && ScrWork[SW_SYSMENUCT] > 0 &&
-             State == Hidden) {
+  } else if (GetFlag(SF_SAVEMENU) && sysMenuCt > 0 && State == Hidden) {
     Show();
   }
 
-  if (MenuTransition.IsOut() &&
-      (ScrWork[SW_SYSMENUCT] == 0 || GetFlag(SF_SYSTEMMENU)) &&
-      State == Hiding) {
+  if (MenuTransition.IsOut() && !GetFlag(SF_SAVEMENU) && systemMenuCHG == 0 &&
+      (sysMenuCt == 0 || GetFlag(SF_SYSTEMMENU)) && State == Hiding) {
     State = Hidden;
     SavePages->at(*CurrentPage)->Hide();
-  } else if (MenuTransition.IsIn() && ScrWork[SW_SYSMENUCT] == 10000 &&
-             State == Showing) {
+  } else if (MenuTransition.IsIn() && sysMenuCt == 10000 &&
+             (systemMenuCHG == 0 || systemMenuCHG == 64) &&
+             GetFlag(SF_SAVEMENU) && State == Showing) {
     State = Shown;
     SavePages->at(*CurrentPage)->HasFocus = true;
     SaveEntryButton::FocusedAlphaFadeStart();

--- a/src/games/chlcc/tipsmenu.cpp
+++ b/src/games/chlcc/tipsmenu.cpp
@@ -226,17 +226,19 @@ void TipsMenu::UpdateInput(float dt) {
 }
 
 void TipsMenu::Update(float dt) {
-  if ((!GetFlag(SF_TIPSMENU) || ScrWork[SW_SYSMENUCT] < 10000) &&
+  const int sysMenuCt = ScrWork[SW_SYSMENUCT];
+  const int systemMenuCHG = ScrWork[SW_SYSTEMMENUCHG];
+
+  if ((!GetFlag(SF_TIPSMENU) || sysMenuCt < 10000 ||
+       (sysMenuCt == 10000 && systemMenuCHG != 0 && systemMenuCHG != 64)) &&
       State == Shown) {
     Hide();
-  } else if (GetFlag(SF_TIPSMENU) && ScrWork[SW_SYSMENUCT] > 0 &&
-             State == Hidden) {
+  } else if (GetFlag(SF_TIPSMENU) && sysMenuCt > 0 && State == Hidden) {
     Show();
   }
 
-  if (FadeAnimation.IsOut() &&
-      (ScrWork[SW_SYSMENUCT] == 0 || GetFlag(SF_SYSTEMMENU)) &&
-      State == Hiding) {
+  if (FadeAnimation.IsOut() && !GetFlag(SF_TIPSMENU) && systemMenuCHG == 0 &&
+      (sysMenuCt == 0 || GetFlag(SF_SYSTEMMENU)) && State == Hiding) {
     State = Hidden;
 
     (*ItemsList.GetCurrent())->Hide();
@@ -248,8 +250,9 @@ void TipsMenu::Update(float dt) {
     TipsSystem::GetNewTipsIndices().resize(0);
     CurrentlyDisplayedTipId = -1;
     if (LastFocusedMenu) LastFocusedMenu->IsFocused = true;
-  } else if (FadeAnimation.IsIn() && ScrWork[SW_SYSMENUCT] == 10000 &&
-             State == Showing) {
+  } else if (FadeAnimation.IsIn() && sysMenuCt == 10000 &&
+             (systemMenuCHG == 0 || systemMenuCHG == 64) &&
+             GetFlag(SF_TIPSMENU) && State == Showing) {
     State = Shown;
     IsFocused = true;
     (*ItemsList.GetCurrent())->HasFocus = true;

--- a/src/games/chlcc/trophymenu.cpp
+++ b/src/games/chlcc/trophymenu.cpp
@@ -197,23 +197,27 @@ void TrophyMenu::UpdateInput(float dt) {
 void TrophyMenu::Update(float dt) {
   UpdateInput(dt);
 
-  if ((!GetFlag(SF_ACHIEVEMENTMENU) || ScrWork[SW_SYSMENUCT] < 10000) &&
+  const int sysMenuCt = ScrWork[SW_SYSMENUCT];
+  const int systemMenuCHG = ScrWork[SW_SYSTEMMENUCHG];
+
+  if ((!GetFlag(SF_ACHIEVEMENTMENU) || sysMenuCt < 10000 ||
+       (sysMenuCt == 10000 && systemMenuCHG != 0 && systemMenuCHG != 64)) &&
       State == Shown) {
     Hide();
-  } else if (GetFlag(SF_ACHIEVEMENTMENU) && ScrWork[SW_SYSMENUCT] > 0 &&
-             State == Hidden) {
+  } else if (GetFlag(SF_ACHIEVEMENTMENU) && sysMenuCt > 0 && State == Hidden) {
     Show();
   }
 
-  if (MenuTransition.IsOut() &&
-      (ScrWork[SW_SYSMENUCT] == 0 || GetFlag(SF_SYSTEMMENU)) &&
+  if (MenuTransition.IsOut() && !GetFlag(SF_ACHIEVEMENTMENU) &&
+      systemMenuCHG == 0 && (sysMenuCt == 0 || GetFlag(SF_SYSTEMMENU)) &&
       State == Hiding) {
     State = Hidden;
     for (int i = 0; i < 9; i++) {
       MainItems[i].Clear();
     }
-  } else if (MenuTransition.IsIn() && ScrWork[SW_SYSMENUCT] == 10000 &&
-             State == Showing) {
+  } else if (MenuTransition.IsIn() && sysMenuCt == 10000 &&
+             (systemMenuCHG == 0 || systemMenuCHG == 64) &&
+             GetFlag(SF_ACHIEVEMENTMENU) && State == Showing) {
     State = Shown;
   }
 


### PR DESCRIPTION
When closing a submenu (e.g. backlog, config, tips, save, load) opened from the system menu in C;H LCC, the game holds for a few seconds before actually closing. This PR fixes that

When opening a menu from the system menu, `SW_SYSMENUCT` is already at 10000, because the system menu is fully transitioned in. Instead, the game then uses `SW_SYSTEMMENUCHG` to mark the progress of the transition animation

When opening, it sets `SW_SYSTEMMENUCHG` to 0, and increments it in a loop until it reaches 64, at which point it will move to that menu's main instruction
When closing, it will then decrement it again in a loop until it reaches 0

When not opening/closing through the system menu, it will simply use `SW_SYSMENUCT`, leaving `SW_SYSTEMMENUCHG` untouched at 0