### PR TITLE
[CCLCC] SSE bugs fix.

### DIFF
--- a/src/games/cclcc/albummenu.cpp
+++ b/src/games/cclcc/albummenu.cpp
@@ -583,7 +583,9 @@ void AlbumMenu::Update(float dt) {
   if (!CGViewer) {
     UpdateThumbnail(dt);
     if (CurrentlyFocusedElement != prevBtn) {
-      Audio::PlayInGroup(Audio::ACG_SE, "sysse", 1, false, 0);
+      if (State == Shown && IsFocused && prevBtn != nullptr) {
+        Audio::PlayInGroup(Audio::ACG_SE, "sysse", 1, false, 0);
+      }
       ThumbnailThumbBlink.StartIn();
     }
   } else {

--- a/src/ui/widgets/cclcc/titlebutton.cpp
+++ b/src/ui/widgets/cclcc/titlebutton.cpp
@@ -3,6 +3,7 @@
 #include "../../../renderer/renderer.h"
 #include "../../../inputsystem.h"
 #include "../../../profile/games/cclcc/titlemenu.h"
+#include "../../../vm/interface/input.h"
 
 namespace Impacto {
 namespace UI {
@@ -40,7 +41,12 @@ void TitleButton::Update(float dt) {
   }
   if (PrevFocusState != HasFocus) {
     PrevFocusState = HasFocus;
-    if (Input::CurrentInputDevice != Input::Device::Mouse) {
+    if (Input::CurrentInputDevice != Input::Device::Mouse &&
+        ((Vm::Interface::PADinputButtonWentDown |
+          Vm::Interface::PADinputButtonRepeatDown |
+          Vm::Interface::PADinputButtonRepeatAccelDown) &
+         (IsSubButton ? (Vm::Interface::PAD1LEFT | Vm::Interface::PAD1RIGHT)
+                      : (Vm::Interface::PAD1UP | Vm::Interface::PAD1DOWN)))) {
       Audio::PlayInGroup(Audio::ACG_SE, "sysse", 1, false, 0);
     }
     if (!IsSubButton) {


### PR DESCRIPTION
This PR will fix:
- Selecting sound plays when user enters submenu in Title Menu, using their keyboard or gamepad (Selecting sound in submenu should play only when user is changing selected buttons using their keyboard or gamepad).
- Selecting sound plays when user enters Album menu or exiting Extra menu when Album menu was selected (Selecting sound should play only when user is changing page or changing selected CG).