### PR TITLE
Improve yes/no trigger sprite transformations

### DIFF
--- a/profiles/cclcc/yesnotrigger.lua
+++ b/profiles/cclcc/yesnotrigger.lua
@@ -106,19 +106,19 @@ root.Sprites["YNChipBlurBg2"] = {
 };
 root.Sprites["YN1ChipYesL"] = {
     Sheet = "YesNoChip",
-    Bounds = { X = 1056.0, Y = 0, Width = 96, Height = 64 }
+    Bounds = { X = 1056.0, Y = 0, Width = 96, Height = 55 }
 };
 root.Sprites["YN1ChipNoL"] = {
     Sheet = "YesNoChip",
-    Bounds = { X = 1056.0, Y = 64, Width = 96, Height = 64 }
+    Bounds = { X = 1056.0, Y = 65, Width = 96, Height = 46 }
 };
 root.Sprites["YN1ChipYesS"] = {
     Sheet = "YesNoChip",
-    Bounds = { X = 1056.0, Y = 128.0, Width = 96, Height = 64 }
+    Bounds = { X = 1056.0, Y = 128.0, Width = 96, Height = 55 }
 };
 root.Sprites["YN1ChipNoS"] = {
     Sheet = "YesNoChip",
-    Bounds = { X = 1056.0, Y = 192.0, Width = 96, Height = 64 }
+    Bounds = { X = 1056.0, Y = 196.0, Width = 96, Height = 45 }
 };
 root.Sprites["YN2ChipYesL"] = {
     Sheet = "YesNoChip",
@@ -138,7 +138,7 @@ root.Sprites["YN2ChipNoS"] = {
 };
 root.Sprites["YNChipStar"] = {
     Sheet = "YesNoChip",
-    Bounds = { X = 1024.0, Y = 374.0, Width = 400.0, Height = 400 }
+    Bounds = { X = 1033.0, Y = 385.0, Width = 380, Height = 380 }
 };
 root.Sprites["YNBgOverlay"] = {
     Sheet = "MenuChip",

--- a/src/games/cclcc/yesnotrigger.cpp
+++ b/src/games/cclcc/yesnotrigger.cpp
@@ -225,7 +225,6 @@ void YesNoTrigger::Render() {
   const float alpha =
       std::clamp(static_cast<float>(ScrWork[6433] << 3), 0.0f, 255.0f);
   const glm::vec4 bgtint = glm::vec4(1.0f, 1.0f, 1.0f, alpha / 255.0f);
-  glm::vec2 starPos{};
   ActiveBackground.Bounds =
       Rect(static_cast<int>(BgSpritePos.x + bgXOffset),
            static_cast<int>(BgSpritePos.y + bgYOffset),
@@ -282,6 +281,7 @@ void YesNoTrigger::Render() {
                           0.5f * BgSpriteScale;
     Sprite* activeYesChip;
     Sprite* activeNoChip;
+    glm::vec2 selectedChipSmallSize;
     const glm::vec4 chipTint = glm::vec4(1.0f, 1.0f, 1.0f, alpha / 255.0f);
 
     if (BgType == BGType::BG0 || BgType == BGType::BG1) {
@@ -289,38 +289,46 @@ void YesNoTrigger::Render() {
           (Selection == YesNoSelect::YES) ? &YN1YesChipLarge : &YN1YesChipSmall;
       activeNoChip =
           (Selection == YesNoSelect::NO) ? &YN1NoChipLarge : &YN1NoChipSmall;
-
-      if (Selection == YesNoSelect::YES) {
-        starPos = yesChipPos - glm::vec2(132.0f, 166.0f);
-      } else if (Selection == YesNoSelect::NO) {
-        starPos = noChipPos - glm::vec2(132.0f, 166.0f);
-      }
-
+      selectedChipSmallSize =
+          ((Selection == YesNoSelect::YES) ? YN1YesChipSmall : YN1NoChipSmall)
+              .Bounds.GetSize();
     } else /* if (BgType == BGType::BG2 || BgType == BGType::BG3) */ {
       activeYesChip =
           (Selection == YesNoSelect::YES) ? &YN2YesChipLarge : &YN2YesChipSmall;
       activeNoChip =
           (Selection == YesNoSelect::NO) ? &YN2NoChipLarge : &YN2NoChipSmall;
-
-      if (Selection == YesNoSelect::YES) {
-        starPos = yesChipPos - glm::vec2(92.0f, 147.0f);
-      } else if (Selection == YesNoSelect::NO) {
-        starPos = noChipPos - glm::vec2(92.0f, 147.0f);
-      }
+      selectedChipSmallSize =
+          ((Selection == YesNoSelect::YES) ? YN2YesChipSmall : YN2NoChipSmall)
+              .Bounds.GetSize();
     }
     const glm::vec2 yesChipSize =
         0.5f * BgSpriteScale * activeYesChip->Bounds.GetSize();
     const glm::vec2 noChipSize =
         0.5f * BgSpriteScale * activeNoChip->Bounds.GetSize();
-    const RectF yesChipDest =
+    RectF yesChipDest =
         RectF(yesChipPos.x, yesChipPos.y, yesChipSize.x, yesChipSize.y);
-    const RectF noChipDest =
+    RectF noChipDest =
         RectF(noChipPos.x, noChipPos.y, noChipSize.x, noChipSize.y);
+
     if (Selection != YesNoSelect::NONE) {
-      const CornersQuad dest = StarChip.ScaledBounds()
-                                   .RotateAroundCenter(StarAnimation.Progress)
-                                   .Translate(starPos);
-      Renderer->DrawSprite(StarChip, dest, chipTint);
+      const glm::vec2 selectedChipPos =
+          (Selection == YesNoSelect::YES) ? yesChipPos : noChipPos;
+      const glm::vec2 activeSmallChipCenter =
+          selectedChipPos + selectedChipSmallSize * 0.5f * 0.5f * BgSpriteScale;
+
+      if (Selection == YesNoSelect::YES) {
+        yesChipDest.SetPos(activeSmallChipCenter - yesChipSize * 0.5f);
+      } else {
+        noChipDest.SetPos(activeSmallChipCenter - noChipSize * 0.5f);
+      }
+
+      const glm::vec2 starTopLeft =
+          activeSmallChipCenter - StarChip.Bounds.GetSize() * 0.5f;
+      const CornersQuad starDest =
+          StarChip.ScaledBounds()
+              .RotateAroundCenter(StarAnimation.Progress)
+              .Translate(starTopLeft);
+      Renderer->DrawSprite(StarChip, starDest, chipTint);
     }
 
     YesClickArea.Bounds = yesChipDest;


### PR DESCRIPTION
Addresses https://github.com/CommitteeOfZero/impacto/issues/307

- Removed ps4 specific hardcoded offset numbers
- Big Yes/No chips and Star are now dynamically center themselves based on the center of the small yes/no chip
- Adjusted sprite bounds so each sprite is placed more in the center of it's bounding box

Before:

<a href="https://github.com/user-attachments/assets/5673fc52-384d-461d-a09d-d5719b81692e" target="_blank">
  <img src="https://github.com/user-attachments/assets/5673fc52-384d-461d-a09d-d5719b81692e" width="200">
</a>

After:

<a href="https://github.com/user-attachments/assets/c52d8102-92d2-469c-8964-321ad4e495bd" target="_blank">
  <img src="https://github.com/user-attachments/assets/c52d8102-92d2-469c-8964-321ad4e495bd" width="200">
</a>

Dev proof:
[Impacto](https://youtu.be/jexdKajn-jU)
[Vita](https://youtu.be/gqilk4e_rSU)

