### PR TITLE
Add support for opening the in-game Backlog menu by scrolling up and close it when fully scrolled down, and scrolling down more.

### DIFF
--- a/src/profile/game.cpp
+++ b/src/profile/game.cpp
@@ -27,6 +27,8 @@ void LoadGameFromLua() {
   ResolutionHeight = EnsureGetMember<int>("ResolutionHeight");
   Fullscreen = EnsureGetMember<bool>("Fullscreen");
   Subtitles = EnsureGetMember<char const*>("Subtitles");
+  CloseBacklogWhenReachedEnd =
+      TryGetMember<bool>("CloseBacklogWhenReachedEnd").value_or(true);
 
   bool res = TryGetMember<bool>("LayFileBigEndian", LayFileBigEndian);
   if (!res) LayFileBigEndian = false;

--- a/src/profile/game.h
+++ b/src/profile/game.h
@@ -43,6 +43,7 @@ inline int ResolutionWidth;
 inline int ResolutionHeight;
 inline bool Fullscreen;
 inline char const* Subtitles;
+inline bool CloseBacklogWhenReachedEnd = true;
 
 inline int PlatformId = 0;
 

--- a/src/ui/backlogmenu.cpp
+++ b/src/ui/backlogmenu.cpp
@@ -1,5 +1,7 @@
 #include "backlogmenu.h"
 
+#include <limits>
+
 #include "ui.h"
 #include "../profile/game.h"
 #include "../profile/vm.h"
@@ -205,6 +207,19 @@ void BacklogMenu::UpdateInput(float dt) {
   MainScrollbar->UpdateInput(dt);
   UpdatePageUpDownInput(dt);
   UpdateScrollingInput(dt);
+
+  if (!(State == Shown && IsFocused)) {
+    AtBottomPrev = false;
+  } else if (Profile::CloseBacklogWhenReachedEnd) {
+    const float epsilon = std::numeric_limits<float>::epsilon();
+    const bool atBottomNow = !MainScrollbar->Enabled ||
+                             (PageY <= (MainScrollbar->EndValue + epsilon));
+
+    if (AtBottomPrev && atBottomNow && Input::MouseWheelDeltaY < 0) {
+      Vm::Interface::PADinputMouseWentDown |= Vm::Interface::PADcustom[6];
+    }
+    AtBottomPrev = atBottomNow;
+  }
 }
 
 void BacklogMenu::Update(float dt) {

--- a/src/ui/backlogmenu.h
+++ b/src/ui/backlogmenu.h
@@ -45,6 +45,9 @@ class BacklogMenu : public Menu {
   void RenderHighlight(glm::vec2 offset = {0.0f, 0.0f}) const;
   void UpdatePageUpDownInput(float dt);
   void UpdateScrollingInput(float dt);
+
+ private:
+  bool AtBottomPrev = false;
 };
 
 }  // namespace UI

--- a/src/vm/interface/input.cpp
+++ b/src/vm/interface/input.cpp
@@ -188,6 +188,10 @@ void UpdatePADInput() {
   else if (Input::TouchWentDown[0])
     PADinputMouseWentDown |= PAD1A;
   if (Input::TouchIsDown[0]) PADinputMouseIsDown |= PAD1A;
+
+  if (Input::MouseWheelDeltaY > 0) {
+    PADinputMouseWentDown |= PADcustom[12];
+  }
 }
 
 // TODO: Make this configurable per game


### PR DESCRIPTION
This PR will add support for opening the in-game Backlog menu by scrolling up and close it when fully scrolled down, and scrolling down more (with mouse). It will also close Backlog if scrolling is unavaible (for example, when Backlog has only 1-2 lines.)