### PR TITLE
Select the button in SystemMenu that was last selected before closing System Menu.

### DIFF
--- a/src/games/cclcc/systemmenu.cpp
+++ b/src/games/cclcc/systemmenu.cpp
@@ -108,13 +108,24 @@ void SystemMenu::Show() {
       UI::FocusedMenu = this;
       ItemsFade.StartIn();
       MainItems->Show();
-      if (!CurrentlyFocusedElement) AdvanceFocus(FDIR_DOWN);
+      if (LastFocusedButtonId && *LastFocusedButtonId < MenuEntriesNum) {
+        CurrentlyFocusedElement = MainItems->Children[*LastFocusedButtonId];
+        CurrentlyFocusedElement->HasFocus = true;
+      } else if (!CurrentlyFocusedElement) {
+        AdvanceFocus(FDIR_DOWN);
+      }
     }
   }
 }
 
 void SystemMenu::Hide() {
   if (State != Hidden) {
+    if (CurrentlyFocusedElement) {
+      auto* btn = static_cast<Widgets::Button*>(CurrentlyFocusedElement);
+      if (btn) {
+        LastFocusedButtonId = btn->Id;
+      }
+    }
     State = Hiding;
     MenuFade.StartOut();
     MenuTransition.StartOut();

--- a/src/games/cclcc/systemmenu.h
+++ b/src/games/cclcc/systemmenu.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <optional>
 #include <glm/fwd.hpp>
 #include "../../ui/menu.h"
 #include "../../ui/widgets/group.h"
@@ -36,6 +37,7 @@ class SystemMenu : public Menu {
   Animation ItemsFade;
   bool ItemsFadeComplete = false;
   glm::vec2 BGPosition{};
+  std::optional<int> LastFocusedButtonId;
 
   GridVertices Vertices;
 

--- a/src/games/chlcc/systemmenu.cpp
+++ b/src/games/chlcc/systemmenu.cpp
@@ -85,7 +85,13 @@ void SystemMenu::Show() {
     }
     IsFocused = true;
     UI::FocusedMenu = this;
-    if (!CurrentlyFocusedElement) AdvanceFocus(FDIR_DOWN);
+
+    if (LastFocusedButtonId && *LastFocusedButtonId < MenuEntriesNum) {
+      CurrentlyFocusedElement = MainItems->Children[*LastFocusedButtonId];
+      CurrentlyFocusedElement->HasFocus = true;
+    } else if (!CurrentlyFocusedElement) {
+      AdvanceFocus(FDIR_DOWN);
+    }
   }
 
   bool noFreeSlots = SaveSystem::MaxSaveEntries ==
@@ -95,6 +101,13 @@ void SystemMenu::Show() {
 
 void SystemMenu::Hide() {
   if (State != Hidden) {
+    if (CurrentlyFocusedElement) {
+      auto* btn = static_cast<Widgets::Button*>(CurrentlyFocusedElement);
+      if (btn) {
+        LastFocusedButtonId = btn->Id;
+      }
+    }
+
     State = Hiding;
     MenuTransition.StartOut();
     if (LastFocusedMenu != 0) {

--- a/src/games/chlcc/systemmenu.h
+++ b/src/games/chlcc/systemmenu.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <optional>
 #include "../../ui/menu.h"
 #include "../../ui/savemenu.h"
 #include "../../ui/widgets/group.h"
@@ -47,6 +48,7 @@ class SystemMenu : public Menu {
   float CurrentRunningPosition = 0.0f;
   float SelectionOffsetY = 0.0f;
   int IndexOfActiveButton = 0;
+  std::optional<int> LastFocusedButtonId;
   glm::vec2 RedTitleLabelPos;
   glm::vec2 RightTitlePos;
   glm::vec2 LeftTitlePos;

--- a/src/games/mo6tw/systemmenu.cpp
+++ b/src/games/mo6tw/systemmenu.cpp
@@ -57,10 +57,20 @@ void SystemMenu::Show() {
     }
     IsFocused = true;
     UI::FocusedMenu = this;
+    if (LastFocusedButtonId && *LastFocusedButtonId < MenuEntriesNum) {
+      CurrentlyFocusedElement = MainItems->Children[*LastFocusedButtonId];
+      CurrentlyFocusedElement->HasFocus = true;
+    }
   }
 }
 void SystemMenu::Hide() {
   if (State != Hidden) {
+    if (CurrentlyFocusedElement) {
+      auto* btn = static_cast<Widgets::Button*>(CurrentlyFocusedElement);
+      if (btn) {
+        LastFocusedButtonId = btn->Id;
+      }
+    }
     State = Hiding;
     FadeAnimation.StartOut();
     MainItems->Hide();

--- a/src/games/mo6tw/systemmenu.h
+++ b/src/games/mo6tw/systemmenu.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <optional>
 #include "../../ui/menu.h"
 #include "../../ui/widgets/group.h"
 #include "../../ui/widgets/button.h"
@@ -22,6 +23,7 @@ class SystemMenu : public Menu {
  private:
   Widgets::Group* MainItems;
   Animation FadeAnimation;
+  std::optional<int> LastFocusedButtonId;
 };
 
 }  // namespace MO6TW

--- a/src/games/mo8/systemmenu.cpp
+++ b/src/games/mo8/systemmenu.cpp
@@ -66,10 +66,23 @@ void SystemMenu::Show() {
     }
     IsFocused = true;
     UI::FocusedMenu = this;
+
+    if (LastFocusedButtonId && *LastFocusedButtonId < MenuEntriesNum) {
+      CurrentlyFocusedElement = MainItems->Children[*LastFocusedButtonId];
+      CurrentlyFocusedElement->HasFocus = true;
+    }
   }
 }
+
 void SystemMenu::Hide() {
   if (State != Hidden) {
+    if (CurrentlyFocusedElement) {
+      auto* btn = static_cast<Widgets::Button*>(CurrentlyFocusedElement);
+      if (btn) {
+        LastFocusedButtonId = btn->Id;
+      }
+    }
+
     State = Hiding;
     FadeAnimation.StartOut();
     MainItems->Hide();

--- a/src/games/mo8/systemmenu.h
+++ b/src/games/mo8/systemmenu.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <optional>
 #include "../../ui/menu.h"
 #include "../../ui/widgets/group.h"
 #include "../../ui/widgets/button.h"
@@ -22,6 +23,7 @@ class SystemMenu : public Menu {
  private:
   Widgets::Group* MainItems;
   Animation FadeAnimation;
+  std::optional<int> LastFocusedButtonId;
 };
 
 }  // namespace MO8

--- a/src/games/rne/systemmenu.cpp
+++ b/src/games/rne/systemmenu.cpp
@@ -58,10 +58,22 @@ void SystemMenu::Show() {
     }
     IsFocused = true;
     UI::FocusedMenu = this;
+
+    if (LastFocusedButtonId && *LastFocusedButtonId < MenuEntriesNum) {
+      CurrentlyFocusedElement = MainItems->Children[*LastFocusedButtonId];
+      CurrentlyFocusedElement->HasFocus = true;
+    }
   }
 }
 void SystemMenu::Hide() {
   if (State != Hidden) {
+    if (CurrentlyFocusedElement) {
+      auto* btn = static_cast<Widgets::Button*>(CurrentlyFocusedElement);
+      if (btn) {
+        LastFocusedButtonId = btn->Id;
+      }
+    }
+
     State = Hiding;
     HighlightAnimation.StartOut();
     for (auto& item : MainItems->Children) {

--- a/src/games/rne/systemmenu.h
+++ b/src/games/rne/systemmenu.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <optional>
 #include "../../ui/menu.h"
 #include "../../ui/widgets/group.h"
 #include "../../ui/widgets/button.h"
@@ -22,6 +23,7 @@ class SystemMenu : public Menu {
  private:
   Widgets::Group* MainItems;
   Animation FadeAnimation;
+  std::optional<int> LastFocusedButtonId;
 };
 
 }  // namespace RNE


### PR DESCRIPTION
This PR will add:
- When user selects, for example, Load button in SystemMenu, closes SystemMenu (or loads a save file in SystemMenu), and then reopens SystemMenu, the Load button will be selected.