### PR TITLE
Menu hitboxes polish

### DIFF
--- a/src/games/cclcc/systemmenu.cpp
+++ b/src/games/cclcc/systemmenu.cpp
@@ -18,6 +18,7 @@ using namespace Impacto::Profile::ScriptVars;
 using namespace Impacto::Vm::Interface;
 using namespace Impacto::Profile::SystemMenu;
 using namespace Impacto::UI::Widgets::CCLCC;
+using namespace Impacto::Input;
 
 void SystemMenu::MenuButtonOnClick(Widgets::Button* target) {
   target->Hovered = false;
@@ -200,6 +201,24 @@ void SystemMenu::Update(float dt) {
 
   if (State == Shown && IsFocused) {
     MainItems->Update(dt);
+
+    if ((CurrentInputDevice == Device::Mouse ||
+         CurrentInputDevice == Device::Touch) &&
+        ((PADinputMouseWentDown & PAD1A))) {
+      bool noButtonsHovered = true;
+      for (auto child : MainItems->Children) {
+        auto button = static_cast<UI::CCLCC::SysMenuButton*>(child);
+        if (button->Hovered) {
+          noButtonsHovered = false;
+          break;
+        }
+      }
+
+      if (noButtonsHovered) {
+        PADinputMouseWentDown = PADinputMouseWentDown & ~PAD1A;
+        PADinputButtonWentDown = PADinputButtonWentDown & ~PAD1A;
+      }
+    }
   }
 }
 

--- a/src/games/chlcc/systemmenu.cpp
+++ b/src/games/chlcc/systemmenu.cpp
@@ -3,6 +3,7 @@
 #include "../../renderer/renderer.h"
 #include "../../ui/ui.h"
 #include "../../vm/interface/input.h"
+#include "../../inputsystem.h"
 #include "../../profile/ui/systemmenu.h"
 #include "../../ui/widgets/chlcc/systemmenuentrybutton.h"
 #include "../../profile/game.h"
@@ -16,6 +17,7 @@ using namespace Impacto::Profile::ScriptVars;
 using namespace Impacto::Vm::Interface;
 using namespace Impacto::Profile::SystemMenu;
 using namespace Impacto::UI::Widgets::CHLCC;
+using namespace Impacto::Input;
 
 void SystemMenu::MenuButtonOnClick(Widgets::Button* target) {
   target->Hovered = false;
@@ -180,6 +182,24 @@ void SystemMenu::Update(float dt) {
     UpdateRunningSelectedLabel(dt);
     MainItems->UpdateInput(dt);
     MainItems->Update(dt);
+
+    if ((CurrentInputDevice == Device::Mouse ||
+         CurrentInputDevice == Device::Touch) &&
+        ((PADinputMouseWentDown & PAD1A))) {
+      bool noButtonsHovered = true;
+      for (auto child : MainItems->Children) {
+        auto button = static_cast<SystemMenuEntryButton*>(child);
+        if (button->Hovered) {
+          noButtonsHovered = false;
+          break;
+        }
+      }
+
+      if (noButtonsHovered) {
+        PADinputMouseWentDown = PADinputMouseWentDown & ~PAD1A;
+        PADinputButtonWentDown = PADinputButtonWentDown & ~PAD1A;
+      }
+    }
   }
 }
 

--- a/src/inputsystem.cpp
+++ b/src/inputsystem.cpp
@@ -31,12 +31,10 @@ void BeginFrame() {
 static glm::vec2 SDLMouseCoordsToDesign(int x, int y) {
   RectF viewport = Window->GetViewport();
   glm::vec2 result;
-  result.x = ((float)x *
-              (Profile::DesignWidth / (viewport.Width * Window->DpiScaleX))) -
-             (viewport.X * Window->DpiScaleX);
-  result.y = ((float)y *
-              (Profile::DesignHeight / (viewport.Height * Window->DpiScaleY))) +
-             (viewport.Y * Window->DpiScaleY);
+  result.x = ((float)x - viewport.X) *
+             (Profile::DesignWidth / (viewport.Width * Window->DpiScaleX));
+  result.y = ((float)y - viewport.Y) *
+             (Profile::DesignHeight / (viewport.Height * Window->DpiScaleY));
   return result;
 }
 


### PR DESCRIPTION
- [X] Fix [empty space clicks triggering menu items](https://github.com/CommitteeOfZero/impacto/issues/305) (menu is handled via script and KeyOnJump instruction)
- [x] Fix [missaligned click areas when resizing the window](https://github.com/CommitteeOfZero/impacto/issues/321)

False clicks:
https://youtu.be/jDz4SM-tNoo
Mouse offset:
https://youtu.be/QqjCFDqAeQ0