### PR TITLE
Yes/No Trigger Fix for touch controls

### DIFF
--- a/src/games/cclcc/yesnotrigger.cpp
+++ b/src/games/cclcc/yesnotrigger.cpp
@@ -417,10 +417,12 @@ void YesNoTrigger::Hide() {
 }
 
 void YesNoTrigger::AreaClick(Widgets::ClickArea* area) {
-  if (IsChoiceBlocked(static_cast<YesNoSelect>(area->Id))) {
+  YesNoSelect selected = static_cast<YesNoSelect>(area->Id);
+  if (IsChoiceBlocked(selected)) {
     Audio::PlayInGroup(Audio::ACG_SE, "sysse", 4, false, 0.0f);
     return;
   }
+  Selection = selected;
   ChooseSelected();
   area->Hovered = false;
 }


### PR DESCRIPTION
This issue can be reproduces on the mouse controls if you'd comment lines 151-164, where selected choice is updated based on hover and only for mouse controls.

And there's a minor edge case for keyboard + mouse:
If you hover "Yes", then via keyboard select "No" and click on the LMB (without moving the mouse, but while still hovering over "Yes") it will choose "No"