### PR TITLE
Fix: SystemMessages choices Padding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -255,6 +255,7 @@ set(Impacto_Src
         src/ui/widgets/chlcc/titlebutton.cpp
         src/ui/widgets/chlcc/saveentrybutton.cpp
         src/ui/widgets/chlcc/systemmenuentrybutton.cpp
+        src/ui/widgets/chlcc/systemmessagebutton.cpp
         src/ui/widgets/chlcc/moviemenuentrybutton.cpp
         src/ui/widgets/chlcc/albumthumbnailbutton.cpp
         src/ui/widgets/chlcc/trackselectbutton.cpp
@@ -579,6 +580,7 @@ set(Impacto_Header
         src/ui/widgets/chlcc/saveentrybutton.h
         src/ui/widgets/chlcc/tipsentrybutton.h
         src/ui/widgets/chlcc/systemmenuentrybutton.h
+        src/ui/widgets/chlcc/systemmessagebutton.h
         src/ui/widgets/chlcc/moviemenuentrybutton.h
         src/ui/widgets/chlcc/albumthumbnailbutton.h
         src/ui/widgets/chlcc/trackselectbutton.h

--- a/profiles/chlcc/font-lb.lua
+++ b/profiles/chlcc/font-lb.lua
@@ -7,7 +7,8 @@ root.Fonts = {
         Rows = 39,
         AdvanceWidths = "games/chlcc/font-lb/widths.bin",
         AdvanceWidthsEmWidth = 60,
-        OutlineOffset = { X = 1, Y = 1 },
+        ForegroundOffset = { X = -7, Y = 0 },
+        OutlineOffset = { X = -6, Y = 1 },
         LineSpacing = 0,
     }
 };

--- a/profiles/chlcc/hud/sysmesboxdisplay.lua
+++ b/profiles/chlcc/hud/sysmesboxdisplay.lua
@@ -55,9 +55,9 @@ root.Sprites[name .. "SelectionLeftPart"] = {
     Sheet = sheet,
     Bounds = {
         X = 504,
-        Y = 53,
-        Width = 152,
-        Height = 33
+        Y = 52,
+        Width = 10,
+        Height = 34
     }
 };
 root.SysMesBoxDisplay.SelectionLeftPart = name .. "SelectionLeftPart";
@@ -65,10 +65,10 @@ root.SysMesBoxDisplay.SelectionLeftPart = name .. "SelectionLeftPart";
 root.Sprites[name .. "SelectionRightPart"] = {
     Sheet = sheet,
     Bounds = {
-        X = 634,
-        Y = 51,
-        Width = 24,
-        Height = 38
+        X = 644,
+        Y = 52,
+        Width = 13,
+        Height = 34
     }
 };
 root.SysMesBoxDisplay.SelectionRightPart = name .. "SelectionRightPart";
@@ -76,10 +76,10 @@ root.SysMesBoxDisplay.SelectionRightPart = name .. "SelectionRightPart";
 root.Sprites[name .. "SelectionMiddlePart"] = {
     Sheet = sheet,
     Bounds = {
-        X = 515,
-        Y = 51,
-        Width = 132,
-        Height = 38
+        X = 518,
+        Y = 52,
+        Width = 124,
+        Height = 34
     }
 };
 root.SysMesBoxDisplay.SelectionMiddlePart = name .. "SelectionMiddlePart";

--- a/src/ui/widgets/button.h
+++ b/src/ui/widgets/button.h
@@ -31,8 +31,8 @@ class Button : public Widget {
                RendererOutlineMode outlineMode, int colorIndex = 10);
   void SetText(Vm::Sc3Stream& stream, float fontSize,
                RendererOutlineMode outlineMode, DialogueColorPair colorPair);
-  void SetText(std::vector<ProcessedTextGlyph> text, float textWidth,
-               float fontSize, RendererOutlineMode outlineMode);
+  virtual void SetText(std::vector<ProcessedTextGlyph> text, float textWidth,
+                       float fontSize, RendererOutlineMode outlineMode);
   void ClearText() {
     Text.clear();
     Bounds = {};

--- a/src/ui/widgets/chlcc/systemmessagebutton.cpp
+++ b/src/ui/widgets/chlcc/systemmessagebutton.cpp
@@ -1,0 +1,72 @@
+#include "systemmessagebutton.h"
+
+#include "../../../profile/dialogue.h"
+
+namespace Impacto {
+namespace UI {
+namespace Widgets {
+namespace CHLCC {
+
+SystemMessageButton::SystemMessageButton(int id, Sprite const& norm,
+                                         Sprite const& focused,
+                                         Sprite const& highlightLeft,
+                                         Sprite const& highlightMiddle,
+                                         Sprite const& highlightRight,
+                                         glm::vec2 pos, RectF hoverBounds)
+    : Button(id, norm, focused, highlightMiddle, pos, hoverBounds) {
+  LeftHighlightSprite = highlightLeft;
+  RightHighlightSprite = highlightRight;
+}
+
+void SystemMessageButton::Render() {
+  if (HasFocus) {
+    const RectF middleDest =
+        HighlightSprite.ScaledBounds()
+            .Scale({Bounds.Width / HighlightSprite.ScaledWidth(), 1.0f},
+                   {0.0f, 0.0f})
+            .Translate(Bounds.GetPos());
+    const RectF leftDest =
+        LeftHighlightSprite.ScaledBounds().Translate(LeftHighlightPos);
+
+    const RectF rightDest =
+        RightHighlightSprite.ScaledBounds().Translate(RightHighlightPos);
+
+    Renderer->DrawSprite(LeftHighlightSprite, leftDest, Tint);
+    Renderer->DrawSprite(HighlightSprite, middleDest, Tint);
+    Renderer->DrawSprite(RightHighlightSprite, rightDest, Tint);
+  }
+
+  if (HasText) {
+    Renderer->DrawProcessedText(Text, Profile::Dialogue::DialogueFont, Tint.a,
+                                OutlineMode, true);
+  }
+}
+
+void SystemMessageButton::SetText(std::vector<ProcessedTextGlyph> text,
+                                  float textWidth, float fontSize,
+                                  RendererOutlineMode outlineMode) {
+  HasText = true;
+  Text = std::move(text);
+  TextWidth = textWidth;
+  OutlineMode = outlineMode;
+  HighlightOffset = glm::vec2(0.0f, -1.0f);
+
+  Bounds = RectF(Text[0].DestRect.X, Text[0].DestRect.Y, TextWidth, fontSize) +
+           HighlightOffset;
+
+  const glm::vec2 leftSize = LeftHighlightSprite.ScaledBounds().GetSize();
+  const float leftWidth = leftSize.x * (fontSize / leftSize.y);
+
+  const glm::vec2 rightSize = RightHighlightSprite.ScaledBounds().GetSize();
+  const float rightWidth = rightSize.x * (fontSize / rightSize.y);
+
+  LeftHighlightPos = {Bounds.X - leftWidth - 1.0f, Bounds.Y};
+  RightHighlightPos = {Bounds.X + TextWidth, Bounds.Y};
+  HoverBounds = RectF(LeftHighlightPos.x, Bounds.Y,
+                      TextWidth + leftWidth + rightWidth, fontSize);
+}
+
+}  // namespace CHLCC
+}  // namespace Widgets
+}  // namespace UI
+}  // namespace Impacto

--- a/src/ui/widgets/chlcc/systemmessagebutton.h
+++ b/src/ui/widgets/chlcc/systemmessagebutton.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "../button.h"
+
+namespace Impacto {
+namespace UI {
+namespace Widgets {
+namespace CHLCC {
+
+class SystemMessageButton : public Button {
+ public:
+  SystemMessageButton(int id, Sprite const& norm, Sprite const& focused,
+                      Sprite const& highlightLeft,
+                      Sprite const& highlightMiddle,
+                      Sprite const& highlightRight, glm::vec2 pos,
+                      RectF hoverBounds = RectF{});
+
+  virtual void Render() override;
+
+  void SetText(std::vector<ProcessedTextGlyph> text, float textWidth,
+               float fontSize, RendererOutlineMode outlineMode) override;
+
+ protected:
+  Sprite LeftHighlightSprite;
+  Sprite RightHighlightSprite;
+  glm::vec2 LeftHighlightPos;
+  glm::vec2 RightHighlightPos;
+};
+
+}  // namespace CHLCC
+}  // namespace Widgets
+}  // namespace UI
+}  // namespace Impacto


### PR DESCRIPTION
- Add new class for stretchable button with 3 parts for system message boxes in CHLCC
- Adjust CHLCC Lb font for better left text alignment
- Minor cleanups
- Minor fixes to the sprite sheets

closes: https://github.com/CommitteeOfZero/impacto/issues/338

Diff overlays for "Load" and "Don't Load":

<img width="1354" height="224" alt="164953" src="https://github.com/user-attachments/assets/6359b7ef-8c31-4e38-92d6-a97635548de4" />

<img width="1530" height="243" alt="165004" src="https://github.com/user-attachments/assets/4b88bb40-c6ed-4d91-8124-3ff2f7e4f55a" />
