### PR TITLE
[CCLCC] Small fixes.

### DIFF
--- a/src/games/cclcc/librarysubmenus.cpp
+++ b/src/games/cclcc/librarysubmenus.cpp
@@ -72,6 +72,10 @@ void LibrarySubmenu::Render() {
 void LibrarySubmenu::Unfocus() {
   if (!IsFocused) return;
 
+  for (auto* child : MainItems.Children) {
+    child->Hovered = false;
+  }
+
   if (UI::FocusedMenu == this) {
     if (LastFocusedMenu != 0) {
       UI::FocusedMenu = LastFocusedMenu;

--- a/src/ui/widgets/cclcc/tipsentrybutton.cpp
+++ b/src/ui/widgets/cclcc/tipsentrybutton.cpp
@@ -76,6 +76,8 @@ void TipsEntryButton::Update(float dt) {
 void TipsEntryButton::UpdateInput(float dt) {
   if (TipsTabBounds.Intersects(Bounds) || TipsTabBounds.Contains(Bounds)) {
     Button::UpdateInput(dt);
+  } else {
+    Hovered = false;
   }
 }
 


### PR DESCRIPTION
This PR will:

- Fix bug when in CCLCC Tips Menu user hovered tip and then scrolled down with mouse and then hovered another tip, and then moved mouse from tip, cursor was still pointer (Hovered state was never getting cleared).
- Fix bug when in CCLCC Extra submenus (album, music, video menu) user hovered something (photo, track or video) and them exited from submenu, cursor was still pointer.