### PR TITLE
CHLCC: Menus Polish

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,6 +161,8 @@ set(Impacto_Src
         src/games/chlcc/titlemenu.cpp
         src/games/chlcc/savemenu.cpp
         src/games/chlcc/sysmesbox.cpp
+        src/games/chlcc/animations/selectprompt.cpp     
+        src/games/chlcc/animations/menutransition.cpp        
         src/games/chlcc/savesystem.cpp
         src/games/chlcc/tipssystem.cpp
         src/games/chlcc/clearlistmenu.cpp
@@ -498,6 +500,8 @@ set(Impacto_Header
         src/games/chlcc/titlemenu.h
         src/games/chlcc/savemenu.h
         src/games/chlcc/sysmesbox.h
+        src/games/chlcc/animations/selectprompt.h
+        src/games/chlcc/animations/menutransition.h        
         src/games/chlcc/savesystem.h
         src/games/chlcc/tipssystem.h
         src/games/chlcc/clearlistmenu.h

--- a/profiles/chlcc/gamespecific.lua
+++ b/profiles/chlcc/gamespecific.lua
@@ -7,12 +7,18 @@ root.GameSpecific = {
   ButterflyFlapFrameDuration = 4/60,
   ButterflyFrameCount = 8,
   ButterflyFadeDuration = 64 / 60,
-  
+
   BubbleSpriteSmall = "BubbleSpriteSmall",
   BubbleSpriteBig = "BubbleSpriteBig",
   BubbleFadeDuration = 64/60,
 
   EyecatchStar = "EyecatchStar",
+
+  MenuSelectPromptDuration =  110 / 60,
+  MenuSelectPromptInterval = 5 / 60,
+  MenuTransitionDuration = 64 / 60,
+  ShowPageAnimationStartTime = 16 / 60,
+  ShowPageAnimationDuration = (48 - 16) / 60,
 };
 
 root.Sprites["MonitorScanline"] = {

--- a/profiles/chlcc/hud/backlogmenu.lua
+++ b/profiles/chlcc/hud/backlogmenu.lua
@@ -1,7 +1,6 @@
 root.BacklogMenu = {
     Type = BacklogMenuType.CHLCC,
     DrawType = DrawComponentType.SystemMenu,
-    TransitionDuration = 64 / 60,
     BackgroundColor = 0x94b1ff,
     CircleSprite = "CircleBacklog",
     CircleStartPosition = { X = 20, Y = 20 },

--- a/profiles/chlcc/hud/extramenus.lua
+++ b/profiles/chlcc/hud/extramenus.lua
@@ -2,7 +2,6 @@ root.ExtraMenus = {
     ClearListMenu = {
         DrawType = DrawComponentType.SystemMenu,
         Type = ClearListMenuType.CHLCC,
-        TransitionDuration = 64 / 60,
         BackgroundColor = 0x405f86,
         CircleSprite = "Circle",
         CircleStartPosition = { X = 20, Y = 20 },
@@ -64,7 +63,6 @@ root.ExtraMenus = {
     MovieMenu = {
         DrawType = DrawComponentType.SystemMenu,
         Type = MovieMenuType.CHLCC,
-        TransitionDuration = 64 / 60,
         BackgroundColor = 0x8e4f9f,
         CircleSprite = "CircleMovie",
         CircleStartPosition = { X = 20, Y = 20 },
@@ -79,8 +77,8 @@ root.ExtraMenus = {
         RedBarSprite = "RedBar",
         RedBarLabelPosition = { X = 1067, Y = 573 },
         RedBarLabel = "RedBarLabel",
-        MenuTitleTextRightPos = { X = 790, Y = 75 },
-        MenuTitleTextLeftPos = { X = 6, Y = 3 },
+        MenuTitleTextRightPos = { X = 788, Y = 80 },
+        MenuTitleTextLeftPos = { X = 3, Y = 3 },
         MenuTitleTextAngle = 4.45,
         TitleFadeInDuration = 40 / 60,
         TitleFadeOutDuration = 28 / 60,
@@ -104,20 +102,19 @@ root.ExtraMenus = {
         ButtonPromptSprite = "MovieButtonPrompt",
         SelectedMovieAnimation = "SelectedMovieAnimDef",
         SelectedMovieYellowDot = "SelectedMovieYellowDot",
-        SelectMovieFadeDuration = 110 / 60,
         SelectMovie = {},
         SelectMoviePos = {
             { X = 94, Y = 51 },
-            { X = 109, Y = 51 },
-            { X = 122, Y = 51 },
-            { X = 134, Y = 51 },
-            { X = 147, Y = 51 },
-            { X = 161, Y = 51 },
-            { X = 180, Y = 51 },
-            { X = 199, Y = 51 },
-            { X = 213, Y = 51 },
-            { X = 229, Y = 51 },
-            { X = 234, Y = 51 },
+            { X = 107, Y = 51 },
+            { X = 120, Y = 51 },
+            { X = 132, Y = 51 },
+            { X = 146, Y = 51 },
+            { X = 158, Y = 51 },
+            { X = 178, Y = 51 },
+            { X = 197, Y = 51 },
+            { X = 211, Y = 51 },
+            { X = 228, Y = 51 },
+            { X = 233, Y = 51 },
         },
         MovieExtraVideosEnabled = true,
         MovieBoxExtra = "MovieBoxExtra",
@@ -129,7 +126,6 @@ root.ExtraMenus = {
     AlbumMenu = {
         DrawType = DrawComponentType.SystemMenu,
         Type = AlbumMenuType.CHLCC,
-        TransitionDuration = 64 / 60,
         BackgroundColor = 0xf36989,
         CircleSprite = "CircleCG",
         CircleStartPosition = { X = 20, Y = 20 },
@@ -170,7 +166,7 @@ root.ExtraMenus = {
         ReachablePageNums = {},
         ButtonGuide = "ButtonGuide",
         ButtonGuidePos = { X = 1019, Y = 651 },
-        SelectData = {},
+        SelectDataSprites = {},
         SelectDataPos = {
             { X = 94, Y = 51 },
             { X = 109, Y = 51 },
@@ -240,25 +236,30 @@ root.ExtraMenus = {
         SoundLibraryTitleAngle = 4.45,
         HighlightStar = "HighlightStar",
         HighlightStarRelativePos = { X = 1, Y = 1 },
+        TrackListBounds = { X = 94, Y = 164, Width = 608, Height = 455},
+        ScrollTrackBounds = { X = 14, Y = 446},
+        ScrollThumb = "ScrollThumb",
+        ScrollbarPosition = { X = 687, Y = 169},
+
         Playlist = {
             8, 14, 26, 10, 28, 12, 20, 16, 18, 24, 22, 80, 76, 32, 34,
             36, 38, 77, 41, 43, 78, 46, 49, 79, 51, 53, 56, 81, 59, 61,
             63, 65, 82, 83, 84, 0, 1, 2, 4, 6, 85, 72, 74, 75, 71
         },
-        SelectSound = {},
+        SelectSoundSprites = {},
         SelectSoundPos = {
-            { X = 94, Y = 51 },
-            { X = 109, Y = 51 },
-            { X = 122, Y = 51 },
-            { X = 134, Y = 51 },
-            { X = 147, Y = 51 },
-            { X = 161, Y = 51 },
-            { X = 178, Y = 51 },
-            { X = 192, Y = 51 },
-            { X = 206, Y = 51 },
-            { X = 220, Y = 51 },
-            { X = 234, Y = 52 },
-        },
+            { X = 85, Y = 49 },
+            { X = 98, Y = 49 },
+            { X = 111, Y = 49 },
+            { X = 123, Y = 49 },
+            { X = 137, Y = 49 },
+            { X = 149, Y = 49 },
+            { X = 170, Y = 49 },
+            { X = 185, Y = 49 },
+            { X = 200, Y = 49 },
+            { X = 215, Y = 49 },
+            { X = 231, Y = 49 },
+        }
     }
 }
 
@@ -454,71 +455,27 @@ root.Sprites["MovieButtonPrompt"] = {
     Bounds = { X = 1, Y = 686, Width = 282, Height = 28 }
 }
 
-root.Sprites["SelectMovie0"] = {
-    Sheet = "Movie",
-    Bounds = { X = 1, Y = 597, Width = 15, Height = 57 }
+local selectMovieBounds = {
+    { X = 1, Y = 597, Width = 15, Height = 57 },
+    { X = 19, Y = 597, Width = 16, Height = 57 },
+    { X = 37, Y = 597, Width = 15, Height = 57 },
+    { X = 53, Y = 597, Width = 16, Height = 57 },
+    { X = 72, Y = 597, Width = 17, Height = 57 },
+    { X = 89, Y = 597, Width = 13, Height = 57 },
+    { X = 114, Y = 597, Width = 21, Height = 57 },
+    { X = 138, Y = 597, Width = 16, Height = 57 },
+    { X = 157, Y = 597, Width = 15, Height = 57 },
+    { X = 179, Y = 597, Width = 7, Height = 57 },
+    { X = 189, Y = 597, Width = 16, Height = 57 }
 }
-root.ExtraMenus.MovieMenu.SelectMovie[#root.ExtraMenus.MovieMenu.SelectMovie + 1] = "SelectMovie0";
 
-root.Sprites["SelectMovie1"] = {
-    Sheet = "Movie",
-    Bounds = { X = 19, Y = 597, Width = 16, Height = 57 }
-}
-root.ExtraMenus.MovieMenu.SelectMovie[#root.ExtraMenus.MovieMenu.SelectMovie + 1] = "SelectMovie1";
-
-root.Sprites["SelectMovie2"] = {
-    Sheet = "Movie",
-    Bounds = { X = 37, Y = 597, Width = 15, Height = 57 }
-}
-root.ExtraMenus.MovieMenu.SelectMovie[#root.ExtraMenus.MovieMenu.SelectMovie + 1] = "SelectMovie2";
-
-root.Sprites["SelectMovie3"] = {
-    Sheet = "Movie",
-    Bounds = { X = 53, Y = 597, Width = 16, Height = 57 }
-}
-root.ExtraMenus.MovieMenu.SelectMovie[#root.ExtraMenus.MovieMenu.SelectMovie + 1] = "SelectMovie3";
-
-root.Sprites["SelectMovie4"] = {
-    Sheet = "Movie",
-    Bounds = { X = 72, Y = 597, Width = 17, Height = 57 }
-}
-root.ExtraMenus.MovieMenu.SelectMovie[#root.ExtraMenus.MovieMenu.SelectMovie + 1] = "SelectMovie4";
-
-root.Sprites["SelectMovie5"] = {
-    Sheet = "Movie",
-    Bounds = { X = 89, Y = 597, Width = 13, Height = 57 }
-}
-root.ExtraMenus.MovieMenu.SelectMovie[#root.ExtraMenus.MovieMenu.SelectMovie + 1] = "SelectMovie5";
-
-root.Sprites["SelectMovie6"] = {
-    Sheet = "Movie",
-    Bounds = { X = 114, Y = 597, Width = 21, Height = 57 }
-}
-root.ExtraMenus.MovieMenu.SelectMovie[#root.ExtraMenus.MovieMenu.SelectMovie + 1] = "SelectMovie6";
-
-root.Sprites["SelectMovie7"] = {
-    Sheet = "Movie",
-    Bounds = { X = 138, Y = 597, Width = 16, Height = 57 }
-}
-root.ExtraMenus.MovieMenu.SelectMovie[#root.ExtraMenus.MovieMenu.SelectMovie + 1] = "SelectMovie7";
-
-root.Sprites["SelectMovie8"] = {
-    Sheet = "Movie",
-    Bounds = { X = 157, Y = 597, Width = 15, Height = 57 }
-}
-root.ExtraMenus.MovieMenu.SelectMovie[#root.ExtraMenus.MovieMenu.SelectMovie + 1] = "SelectMovie8";
-
-root.Sprites["SelectMovie9"] = {
-    Sheet = "Movie",
-    Bounds = { X = 179, Y = 597, Width = 7, Height = 57 }
-}
-root.ExtraMenus.MovieMenu.SelectMovie[#root.ExtraMenus.MovieMenu.SelectMovie + 1] = "SelectMovie9";
-
-root.Sprites["SelectMovie10"] = {
-    Sheet = "Movie",
-    Bounds = { X = 189, Y = 597, Width = 16, Height = 57 }
-}
-root.ExtraMenus.MovieMenu.SelectMovie[#root.ExtraMenus.MovieMenu.SelectMovie + 1] = "SelectMovie10";
+for i, bounds in ipairs(selectMovieBounds) do
+    root.Sprites["SelectMovie" .. i - 1] = {
+        Sheet = "Movie",
+        Bounds = bounds
+    }
+    root.ExtraMenus.MovieMenu.SelectMovie[i] = "SelectMovie" .. i - 1;
+end
 
 root.Sprites["SelectedMovieYellowDot"] = {
     Sheet = "Movie",
@@ -614,71 +571,32 @@ root.Sprites["HighlightStar"] = {
     Bounds = { X = 216, Y = 632, Width = 23, Height = 23 }
 }
 
-root.Sprites["SelectSound0"] = {
-    Sheet = "Sound",
-    Bounds = { X = 2, Y = 633, Width = 15, Height = 58 }
+local selectSoundBounds = {
+    { X = 2, Y = 633, Width = 15, Height = 58 },
+    { X = 20, Y = 633, Width = 16, Height = 58 },
+    { X = 38, Y = 633, Width = 15, Height = 58 },
+    { X = 54, Y = 633, Width = 16, Height = 58 },
+    { X = 73, Y = 633, Width = 15, Height = 58 },
+    { X = 90, Y = 633, Width = 13, Height = 58 },
+    { X = 116, Y = 633, Width = 16, Height = 58 },
+    { X = 136, Y = 633, Width = 16, Height = 58 },
+    { X = 156, Y = 633, Width = 17, Height = 58 },
+    { X = 176, Y = 633, Width = 18, Height = 58 },
+    { X = 197, Y = 633, Width = 17, Height = 58 }
 }
-root.ExtraMenus.MusicMenu.SelectSound[#root.ExtraMenus.MusicMenu.SelectSound + 1] = "SelectSound0";
 
-root.Sprites["SelectSound1"] = {
-    Sheet = "Sound",
-    Bounds = { X = 20, Y = 633, Width = 16, Height = 58 }
-}
-root.ExtraMenus.MusicMenu.SelectSound[#root.ExtraMenus.MusicMenu.SelectSound + 1] = "SelectSound1";
+for i, bounds in ipairs(selectSoundBounds) do
+    root.Sprites["SelectSound" .. i - 1] = {
+        Sheet = "Sound",
+        Bounds = bounds
+    }
+    root.ExtraMenus.MusicMenu.SelectSoundSprites[i] = "SelectSound" .. i - 1;
+end
 
-root.Sprites["SelectSound2"] = {
+root.Sprites["ScrollThumb"] = {
     Sheet = "Sound",
-    Bounds = { X = 38, Y = 633, Width = 15, Height = 58 }
+    Bounds = { X = 241, Y = 632, Width = 14, Height = 59 }
 }
-root.ExtraMenus.MusicMenu.SelectSound[#root.ExtraMenus.MusicMenu.SelectSound + 1] = "SelectSound2";
-
-root.Sprites["SelectSound3"] = {
-    Sheet = "Sound",
-    Bounds = { X = 54, Y = 633, Width = 16, Height = 58 }
-}
-root.ExtraMenus.MusicMenu.SelectSound[#root.ExtraMenus.MusicMenu.SelectSound + 1] = "SelectSound3";
-
-root.Sprites["SelectSound4"] = {
-    Sheet = "Sound",
-    Bounds = { X = 73, Y = 633, Width = 15, Height = 58 }
-}
-root.ExtraMenus.MusicMenu.SelectSound[#root.ExtraMenus.MusicMenu.SelectSound + 1] = "SelectSound4";
-
-root.Sprites["SelectSound5"] = {
-    Sheet = "Sound",
-    Bounds = { X = 90, Y = 633, Width = 13, Height = 58 }
-}
-root.ExtraMenus.MusicMenu.SelectSound[#root.ExtraMenus.MusicMenu.SelectSound + 1] = "SelectSound5";
-
-root.Sprites["SelectSound6"] = {
-    Sheet = "Sound",
-    Bounds = { X = 116, Y = 633, Width = 16, Height = 58 }
-}
-root.ExtraMenus.MusicMenu.SelectSound[#root.ExtraMenus.MusicMenu.SelectSound + 1] = "SelectSound6";
-
-root.Sprites["SelectSound7"] = {
-    Sheet = "Sound",
-    Bounds = { X = 136, Y = 633, Width = 16, Height = 58 }
-}
-root.ExtraMenus.MusicMenu.SelectSound[#root.ExtraMenus.MusicMenu.SelectSound + 1] = "SelectSound7";
-
-root.Sprites["SelectSound8"] = {
-    Sheet = "Sound",
-    Bounds = { X = 156, Y = 633, Width = 17, Height = 58 }
-}
-root.ExtraMenus.MusicMenu.SelectSound[#root.ExtraMenus.MusicMenu.SelectSound + 1] = "SelectSound8";
-
-root.Sprites["SelectSound9"] = {
-    Sheet = "Sound",
-    Bounds = { X = 176, Y = 633, Width = 18, Height = 58 }
-}
-root.ExtraMenus.MusicMenu.SelectSound[#root.ExtraMenus.MusicMenu.SelectSound + 1] = "SelectSound9";
-
-root.Sprites["SelectSound10"] = {
-    Sheet = "Sound",
-    Bounds = { X = 197, Y = 633, Width = 17, Height = 58 }
-}
-root.ExtraMenus.MusicMenu.SelectSound[#root.ExtraMenus.MusicMenu.SelectSound + 1] = "SelectSound10";
 
 --CGList
 root.Sprites["CircleCG"] = {
@@ -765,65 +683,26 @@ root.Sprites["ButtonGuide"] = {
     Bounds = { X = 1, Y = 581, Width = 380, Height = 28 }
 }
 
-root.Sprites["SelectData0"] = {
-    Sheet = "CG",
-    Bounds = { X = 1, Y = 670, Width = 18, Height = 55 }
+local selectDataBounds = {
+    { X = 1, Y = 670, Width = 18, Height = 55 },
+    { X = 21, Y = 670, Width = 16, Height = 55 },
+    { X = 39, Y = 670, Width = 15, Height = 55 },
+    { X = 56, Y = 670, Width = 16, Height = 55 },
+    { X = 74, Y = 670, Width = 17, Height = 55 },
+    { X = 93, Y = 670, Width = 22, Height = 55 },
+    { X = 117, Y = 670, Width = 22, Height = 55 },
+    { X = 141, Y = 670, Width = 17, Height = 55 },
+    { X = 159, Y = 670, Width = 18, Height = 55 },
+    { X = 179, Y = 670, Width = 20, Height = 55 }
 }
-root.ExtraMenus.AlbumMenu.SelectData[#root.ExtraMenus.AlbumMenu.SelectData + 1] = "SelectData0";
 
-root.Sprites["SelectData1"] = {
-    Sheet = "CG",
-    Bounds = { X = 21, Y = 670, Width = 16, Height = 55 }
-}
-root.ExtraMenus.AlbumMenu.SelectData[#root.ExtraMenus.AlbumMenu.SelectData + 1] = "SelectData1";
-
-root.Sprites["SelectData2"] = {
-    Sheet = "CG",
-    Bounds = { X = 39, Y = 670, Width = 15, Height = 55 }
-}
-root.ExtraMenus.AlbumMenu.SelectData[#root.ExtraMenus.AlbumMenu.SelectData + 1] = "SelectData2";
-
-root.Sprites["SelectData3"] = {
-    Sheet = "CG",
-    Bounds = { X = 56, Y = 670, Width = 16, Height = 55 }
-}
-root.ExtraMenus.AlbumMenu.SelectData[#root.ExtraMenus.AlbumMenu.SelectData + 1] = "SelectData3";
-
-root.Sprites["SelectData4"] = {
-    Sheet = "CG",
-    Bounds = { X = 74, Y = 670, Width = 17, Height = 55 }
-}
-root.ExtraMenus.AlbumMenu.SelectData[#root.ExtraMenus.AlbumMenu.SelectData + 1] = "SelectData4";
-
-root.Sprites["SelectData5"] = {
-    Sheet = "CG",
-    Bounds = { X = 93, Y = 670, Width = 22, Height = 55 }
-}
-root.ExtraMenus.AlbumMenu.SelectData[#root.ExtraMenus.AlbumMenu.SelectData + 1] = "SelectData5";
-
-root.Sprites["SelectData6"] = {
-    Sheet = "CG",
-    Bounds = { X = 117, Y = 670, Width = 22, Height = 55 }
-}
-root.ExtraMenus.AlbumMenu.SelectData[#root.ExtraMenus.AlbumMenu.SelectData + 1] = "SelectData6";
-
-root.Sprites["SelectData7"] = {
-    Sheet = "CG",
-    Bounds = { X = 141, Y = 670, Width = 17, Height = 55 }
-}
-root.ExtraMenus.AlbumMenu.SelectData[#root.ExtraMenus.AlbumMenu.SelectData + 1] = "SelectData7";
-
-root.Sprites["SelectData8"] = {
-    Sheet = "CG",
-    Bounds = { X = 159, Y = 670, Width = 18, Height = 55 }
-}
-root.ExtraMenus.AlbumMenu.SelectData[#root.ExtraMenus.AlbumMenu.SelectData + 1] = "SelectData8";
-
-root.Sprites["SelectData9"] = {
-    Sheet = "CG",
-    Bounds = { X = 179, Y = 670, Width = 20, Height = 55 }
-}
-root.ExtraMenus.AlbumMenu.SelectData[#root.ExtraMenus.AlbumMenu.SelectData + 1] = "SelectData9";
+for i, bounds in ipairs(selectDataBounds) do
+    root.Sprites["SelectData" .. i - 1] = {
+        Sheet = "CG",
+        Bounds = bounds
+    }
+    root.ExtraMenus.AlbumMenu.SelectDataSprites[i] = "SelectData" .. i - 1;
+end
 
 root.Sprites["AlbumMenuTitle"] = {
     Sheet = "CG",

--- a/profiles/chlcc/hud/savemenu.lua
+++ b/profiles/chlcc/hud/savemenu.lua
@@ -201,64 +201,23 @@ root.Sprites["SaveButtonPrompt"] = {
     Bounds = {X = 1, Y = 581, Width = 430, Height = 28}
 };
 
--- This is a mess
+local saveMenuFadeTextBounds = {
+    { X = 1, Y = 670, Width = 18, Height = 55 },
+    { X = 21, Y = 670, Width = 16, Height = 55 },
+    { X = 39, Y = 670, Width = 15, Height = 55 },
+    { X = 56, Y = 670, Width = 16, Height = 55 },
+    { X = 74, Y = 670, Width = 17, Height = 55 },
+    { X = 93, Y = 670, Width = 22, Height = 55 },
+    { X = 117, Y = 670, Width = 22, Height = 55 },
+    { X = 141, Y = 670, Width = 17, Height = 55 },
+    { X = 159, Y = 670, Width = 18, Height = 55 },
+    { X = 179, Y = 670, Width = 20, Height = 55 }
+}
 
-root.Sprites["SaveMenuFadeTextS"] = {
-    Sheet = "Save",
-    Bounds = {X = 1, Y = 670, Width = 18, Height = 55}
-};
-root.SaveMenu.SelectDataText[#root.SaveMenu.SelectDataText + 1] = "SaveMenuFadeTextS";
-
-root.Sprites["SaveMenuFadeTextE"] = {
-    Sheet = "Save",
-    Bounds = {X = 21, Y = 670, Width = 16, Height = 55}
-};
-root.SaveMenu.SelectDataText[#root.SaveMenu.SelectDataText + 1] = "SaveMenuFadeTextE";
-
-root.Sprites["SaveMenuFadeTextL"] = {
-    Sheet = "Save",
-    Bounds = {X = 39, Y = 670, Width = 15, Height = 55}
-};
-root.SaveMenu.SelectDataText[#root.SaveMenu.SelectDataText + 1] = "SaveMenuFadeTextL";
-
-root.Sprites["SaveMenuFadeTextE2"] = {
-    Sheet = "Save",
-    Bounds = {X = 56, Y = 670, Width = 16, Height = 55}
-};
-root.SaveMenu.SelectDataText[#root.SaveMenu.SelectDataText + 1] = "SaveMenuFadeTextE2";
-
-root.Sprites["SaveMenuFadeTextC"] = {
-    Sheet = "Save",
-    Bounds = {X = 74, Y = 670, Width = 17, Height = 55}
-};
-root.SaveMenu.SelectDataText[#root.SaveMenu.SelectDataText + 1] = "SaveMenuFadeTextC";
-
-root.Sprites["SaveMenuFadeTextT"] = {
-    Sheet = "Save",
-    Bounds = {X = 93, Y = 670, Width = 22, Height = 55}
-};
-root.SaveMenu.SelectDataText[#root.SaveMenu.SelectDataText + 1] = "SaveMenuFadeTextT";
-
-root.Sprites["SaveMenuFadeTextD"] = {
-    Sheet = "Save",
-    Bounds = {X = 117, Y = 670, Width = 22, Height = 55}
-};
-root.SaveMenu.SelectDataText[#root.SaveMenu.SelectDataText + 1] = "SaveMenuFadeTextD";
-
-root.Sprites["SaveMenuFadeTextA"] = {
-    Sheet = "Save",
-    Bounds = {X = 141, Y = 670, Width = 17, Height = 55}
-};
-root.SaveMenu.SelectDataText[#root.SaveMenu.SelectDataText + 1] = "SaveMenuFadeTextA";
-
-root.Sprites["SaveMenuFadeTextT2"] = {
-    Sheet = "Save",
-    Bounds = {X = 159, Y = 670, Width = 18, Height = 55}
-};
-root.SaveMenu.SelectDataText[#root.SaveMenu.SelectDataText + 1] = "SaveMenuFadeTextT2";
-
-root.Sprites["SaveMenuFadeTextA2"] = {
-    Sheet = "Save",
-    Bounds = {X = 179, Y = 670, Width = 20, Height = 55}
-};
-root.SaveMenu.SelectDataText[#root.SaveMenu.SelectDataText + 1] = "SaveMenuFadeTextA2";
+for i, bounds in ipairs(saveMenuFadeTextBounds) do
+    root.Sprites["SaveMenuFadeText" .. i - 1] = {
+        Sheet = "Save",
+        Bounds = bounds
+    }
+    root.SaveMenu.SelectDataText[i] = "SaveMenuFadeText" .. i - 1;
+end

--- a/profiles/chlcc/hud/systemmenu.lua
+++ b/profiles/chlcc/hud/systemmenu.lua
@@ -43,7 +43,6 @@ root.SystemMenu = {
     MenuSelectedLabelSpeed = -400,
     MenuEntriesNum = 9,
     MenuEntriesHNum = 0,
-    SelectMenuSpritesCount = 10,
     ------
     --Not used since it isn't laid out in a way that would make it easier to use this
     MenuEntriesX = 173,

--- a/profiles/chlcc/hud/tipsmenu.lua
+++ b/profiles/chlcc/hud/tipsmenu.lua
@@ -17,7 +17,7 @@ root.TipsMenu = {
     RedBarLabelPosition = { X = 1067, Y = 573 },
     RedBarLabel = "RedBarLabel",
     MenuTitleTextRightPos = { X = 787, Y = 209 },
-    MenuTitleTextLeftPos = { X = 260, Y = 1 },
+    MenuTitleTextLeftPos = { X = 257, Y = 1 },
     MenuTitleTextAngle = 4.45,
     TitleFadeInDuration = 40 / 60,
     TitleFadeOutDuration = 28 / 60,
@@ -80,6 +80,7 @@ root.TipsMenu = {
     PronounciationInitialBounds = { X = 1210, Y = 110, Width = 0, Height = 0 },
     TipsListEntryDotOffset = { X = -17, Y = -4},
     TipsListNewDotOffset= { X = -40, Y = -4},
+    TipScrollbarPos = { X = 359, Y = 127},
 
     TipsEntryHighlightBarSprite = "TipsEntryHighlightBar",
     TipsEntryHighlightDotSprite = "TipsEntryHighlightDot",
@@ -122,7 +123,7 @@ root.Sprites["RedBarLabel"] = {
 
 root.Sprites["MenuTitleTextTips"] = {
     Sheet = "Tips",
-    Bounds = { X = 1154, Y = 1, Width = 117, Height = 742 }
+    Bounds = { X = 1151, Y = 1, Width = 120, Height = 742 }
 }
 
 root.Sprites["TipsTree"] = {
@@ -193,7 +194,7 @@ root.Sprites["TipsLeftLineHoleEnd"] = {
 }
 root.Sprites["TipsLeftLineEnd"] = {
     Sheet = "Tips",
-    Bounds = { X = 851, Y = 484, Width = 316, Height = 8 }
+    Bounds = { X = 851, Y = 484, Width = 286, Height = 8 }
 }
 root.Sprites["TipsListBgBar"] = {
     Sheet = "Tips",
@@ -205,11 +206,11 @@ root.Sprites["TipsListBgBarHole"] = {
 }
 root.Sprites["TipsScrollThumb"] = {
     Sheet = "Tips",
-    Bounds = { X = 1274, Y = 511, Width = 16, Height = 61 }
+    Bounds = { X = 1275, Y = 512, Width = 14, Height = 60 }
 }
 root.Sprites["TipsScrollTrack"] = {
     Sheet = "Tips",
-    Bounds = { X = 1280, Y = 0, Width = 3, Height = 500 }
+    Bounds = { X = 1281, Y = 0, Width = 2, Height = 499 }
 }
 
 for i = 0, 9 do

--- a/src/animation.h
+++ b/src/animation.h
@@ -6,10 +6,14 @@
 
 namespace Impacto {
 
-enum class AnimationState { Stopped = 0, Playing = 1 };
-enum class AnimationLoopMode { Stop = 0, ReverseDirection = 1, Loop = 2 };
+enum class AnimationState : uint8_t { Stopped = 0, Playing = 1 };
+enum class AnimationLoopMode : uint8_t {
+  Stop = 0,
+  ReverseDirection = 1,
+  Loop = 2
+};
 
-enum class AnimationDirection { In = 1, Out = -1 };
+enum class AnimationDirection : int8_t { In = 1, Out = -1 };
 constexpr AnimationDirection operator-(AnimationDirection direction) {
   return static_cast<AnimationDirection>(static_cast<int>(direction) * -1);
 }
@@ -18,10 +22,10 @@ class Animation {
  public:
   float DurationIn = 0;
   float DurationOut = 0;
-  // 1 = in, -1 = out
-  AnimationDirection Direction = AnimationDirection::In;
   // 0 = fully out, 1 = fully in
   float Progress = 0;
+  // 1 = in, -1 = out
+  AnimationDirection Direction = AnimationDirection::In;
   AnimationState State = AnimationState::Stopped;
   AnimationLoopMode LoopMode = AnimationLoopMode::Stop;
   // Animation skips to the end when skip mode is enabled

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -145,6 +145,7 @@ static void Init() {
     TipsSystem::Init();
     SaveIconDisplay::Init();
     LoadingDisplay::Init();
+    Profile::GameSpecific::Configure();
     Profile::SysMesBox::Configure();
     Profile::TitleMenu::Configure();
     Profile::SystemMenu::Configure();
@@ -155,7 +156,6 @@ static void Init() {
     Profile::HelpMenu::Configure();
     Profile::TipsMenu::Configure();
     Profile::ExtraMenus::Configure();
-    Profile::GameSpecific::Configure();
     DateDisplay::Init();
     TipsNotification::Init();
     // Default controls

--- a/src/games/chlcc/albummenu.h
+++ b/src/games/chlcc/albummenu.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "animations/selectprompt.h"
+#include "animations/menutransition.h"
 #include "../../ui/menu.h"
 #include "../../ui/widgets/group.h"
 #include "../../ui/widgets/button.h"
@@ -28,7 +30,7 @@ class AlbumMenu : public Menu {
   void DrawRedBar();
   void DrawButtonGuide();
 
-  void DrawPage(const glm::vec2 &offset);
+  void DrawPage();
 
   void UpdatePages();
   void UpdateTitles();
@@ -36,21 +38,23 @@ class AlbumMenu : public Menu {
   void CgOnClick(Widgets::Button *target);
   void OnCgVariationEnd(Widgets::CgViewer *target);
 
-  Animation MenuTransition;
   Animation TitleFade;
   Animation FromSystemMenuTransition;
+  SelectPromptAnimation SelectAnimation;
+  MenuTransitionAnimation MenuTransition;
+
+  Widgets::Group *CgViewerGroup;
+  Widgets::CgViewer *CgViewerWidget;
+
+  glm::vec2 RedTitleLabelPos;
+  glm::vec2 RightTitlePos;
+  glm::vec2 LeftTitlePos;
 
   int PrevPage = 0;
   int CurrentPage;
   int MaxReachablePage;
 
-  Widgets::Group *CgViewerGroup;
-  Widgets::CgViewer *CgViewerWidget;
   bool ShowCgViewer = false;
-
-  glm::vec2 RedTitleLabelPos;
-  glm::vec2 RightTitlePos;
-  glm::vec2 LeftTitlePos;
 };
 
 }  // namespace CHLCC

--- a/src/games/chlcc/animations/menutransition.cpp
+++ b/src/games/chlcc/animations/menutransition.cpp
@@ -1,0 +1,42 @@
+#include "menutransition.h"
+
+#include "../../../profile/game.h"
+#include "../../../profile/ui/gamespecific.h"
+
+namespace Impacto {
+namespace UI {
+namespace CHLCC {
+
+using namespace Impacto::Profile;
+using namespace Impacto::Profile::GameSpecific;
+
+MenuTransitionAnimation::MenuTransitionAnimation() {
+  SetDuration(MenuTransitionDuration);
+}
+
+glm::vec2 MenuTransitionAnimation::GetPageOffset() const {
+  glm::vec2 position = {0.0f, 0.0f};
+
+  if (IsIn()) return position;
+
+  const float startProgress =
+      ShowPageAnimationStartTime / MenuTransitionDuration;
+  const float endProgress =
+      startProgress + ShowPageAnimationDuration / MenuTransitionDuration;
+
+  if (startProgress < Progress && Progress < endProgress) {
+    const float progress =
+        (Progress - startProgress) / (endProgress - startProgress);
+    const float angle = progress * std::numbers::pi_v<float> * 0.5f;
+
+    position = {0.0f, (std::sin(angle) - 1.0f) * DesignHeight};
+
+  } else if (Progress <= startProgress) {
+    position = {0.0f, -DesignHeight};
+  }
+  return position;
+}
+
+}  // namespace CHLCC
+}  // namespace UI
+}  // namespace Impacto

--- a/src/games/chlcc/animations/menutransition.h
+++ b/src/games/chlcc/animations/menutransition.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <vector>
+
+#include "../../../animation.h"
+#include "../../../spritesheet.h"
+#include "../../../renderer/renderer.h"
+#include "../../../profile/ui/gamespecific.h"
+
+namespace Impacto {
+namespace UI {
+namespace CHLCC {
+
+class MenuTransitionAnimation : public Animation {
+ public:
+  MenuTransitionAnimation();
+  glm::vec2 GetPageOffset() const;
+};
+}  // namespace CHLCC
+}  // namespace UI
+}  // namespace Impacto

--- a/src/games/chlcc/animations/selectprompt.cpp
+++ b/src/games/chlcc/animations/selectprompt.cpp
@@ -1,0 +1,34 @@
+#include "selectprompt.h"
+
+namespace Impacto {
+namespace UI {
+namespace CHLCC {
+
+SelectPromptAnimation::SelectPromptAnimation() {
+  Direction = AnimationDirection::In;
+  LoopMode = AnimationLoopMode::Loop;
+  DurationIn = MenuSelectPromptDuration;
+  DurationOut = 0.0f;
+}
+
+void SelectPromptAnimation::Draw(const std::span<const Sprite> sprites,
+                                 const std::span<const glm::vec2> positions,
+                                 const glm::vec2 offset) {
+  const auto currentLetter = static_cast<size_t>(
+      Progress * MenuSelectPromptDuration / MenuSelectPromptInterval);
+  for (size_t i = 0; i < sprites.size(); i++) {
+    if (currentLetter < i) break;
+    const glm::vec2 pos = positions[i];
+    const float alpha = i == currentLetter
+                            ? (Progress * MenuSelectPromptDuration -
+                               i * MenuSelectPromptInterval) /
+                                  MenuSelectPromptInterval
+                            : 1.0f;
+    Renderer->DrawSprite(sprites[i], pos + offset,
+                         glm::vec4(1.0f, 1.0f, 1.0f, alpha));
+  }
+}
+
+}  // namespace CHLCC
+}  // namespace UI
+}  // namespace Impacto

--- a/src/games/chlcc/animations/selectprompt.h
+++ b/src/games/chlcc/animations/selectprompt.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <vector>
+
+#include "../../../animation.h"
+#include "../../../spritesheet.h"
+#include "../../../renderer/renderer.h"
+#include "../../../profile/ui/gamespecific.h"
+
+namespace Impacto {
+namespace UI {
+namespace CHLCC {
+using namespace Impacto::Profile::GameSpecific;
+
+class SelectPromptAnimation : public Animation {
+ public:
+  SelectPromptAnimation();
+  void Draw(std::span<const Sprite> sprites,
+            std::span<const glm::vec2> positions, glm::vec2 offset);
+};
+
+}  // namespace CHLCC
+}  // namespace UI
+}  // namespace Impacto

--- a/src/games/chlcc/backlogmenu.cpp
+++ b/src/games/chlcc/backlogmenu.cpp
@@ -15,15 +15,11 @@ namespace UI {
 namespace CHLCC {
 
 using namespace Impacto::Profile::CHLCC::BacklogMenu;
+using namespace Impacto::Profile::GameSpecific;
 using namespace Impacto::UI::Widgets::CHLCC;
 using namespace Impacto::Profile::ScriptVars;
 
 BacklogMenu::BacklogMenu() {
-  MenuTransition.Direction = AnimationDirection::In;
-  MenuTransition.LoopMode = AnimationLoopMode::Stop;
-  MenuTransition.DurationIn = TransitionDuration;
-  MenuTransition.DurationOut = TransitionDuration;
-
   TitleFade.Direction = AnimationDirection::In;
   TitleFade.LoopMode = AnimationLoopMode::Stop;
   TitleFade.DurationIn = TitleFadeInDuration;
@@ -102,13 +98,7 @@ void BacklogMenu::Render() {
 
   float yOffset = 0;
   if (MenuTransition.Progress > 0.22f) {
-    if (MenuTransition.Progress < 0.73f) {
-      // Approximated function from the original, another mess
-      yOffset = glm::mix(
-          -Profile::DesignHeight, 0.0f,
-          1.00397f * std::sin(3.97161f - 3.26438f * MenuTransition.Progress) -
-              0.00295643f);
-    }
+    yOffset = MenuTransition.GetPageOffset().y;
     Renderer->DrawSprite(BacklogBackgroundSprite, {0.0f, 0.0f + yOffset});
     DrawButtonPrompt();
 
@@ -130,13 +120,6 @@ void BacklogMenu::Render() {
     RenderHighlight({0.0f, yOffset});
   }
   if (MenuTransition.Progress > 0.22f) {
-    if (MenuTransition.Progress < 0.73f) {
-      // Approximated function from the original, another mess
-      yOffset = glm::mix(
-          -Profile::DesignHeight, 0.0f,
-          1.00397f * std::sin(3.97161f - 3.26438f * MenuTransition.Progress) -
-              0.00295643f);
-    }
     MainItems->RenderingBounds.Y += yOffset;
     MainItems->Move({0.0f, yOffset});
     MainItems->Render();
@@ -195,7 +178,7 @@ inline void BacklogMenu::DrawCircles() {
   int resetCounter = 0;
   // Give the whole range that mimics ScrWork[SW_SYSMENUCT] given that the
   // duration is totalframes/60
-  float progress = MenuTransition.Progress * TransitionDuration * 60.0f;
+  float progress = MenuTransition.Progress * MenuTransitionDuration * 60.0f;
   for (int line = 0; line < 4; line++) {
     int counter = resetCounter;
     float x = CircleStartPosition.x;
@@ -238,7 +221,7 @@ inline void BacklogMenu::DrawRedBar() {
   } else if (MenuTransition.Progress > 0.70f) {
     // Give the whole range that mimics ScrWork[SW_SYSMENUCT] given that the
     // duration is totalframes/60
-    float progress = MenuTransition.Progress * TransitionDuration * 60.0f;
+    float progress = MenuTransition.Progress * MenuTransitionDuration * 60.0f;
     float pixelPerAdvanceLeft = RedBarBaseX * (progress - 47.0f) / 17.0f;
     RedBarSprite.Bounds.X = RedBarDivision - pixelPerAdvanceLeft;
     RedBarSprite.Bounds.Width = pixelPerAdvanceLeft;

--- a/src/games/chlcc/backlogmenu.h
+++ b/src/games/chlcc/backlogmenu.h
@@ -2,6 +2,7 @@
 
 #include "../../ui/backlogmenu.h"
 #include "../../ui/widgets/chlcc/backlogentry.h"
+#include "animations/menutransition.h"
 
 namespace Impacto {
 namespace UI {
@@ -31,7 +32,7 @@ class BacklogMenu : public UI::BacklogMenu {
 
   void UpdateTitles();
 
-  Animation MenuTransition;
+  MenuTransitionAnimation MenuTransition;
   Animation TitleFade;
   Animation FromSystemMenuTransition;
 

--- a/src/games/chlcc/clearlistmenu.cpp
+++ b/src/games/chlcc/clearlistmenu.cpp
@@ -16,16 +16,12 @@ namespace CHLCC {
 
 using namespace Impacto::Profile::CHLCC::ClearListMenu;
 using namespace Impacto::Profile::ScriptVars;
+using namespace Impacto::Profile::GameSpecific;
 using namespace Impacto::UI::Widgets;
 using namespace Impacto::TipsSystem;
 using namespace Impacto::Profile;
 
 ClearListMenu::ClearListMenu() {
-  MenuTransition.Direction = AnimationDirection::In;
-  MenuTransition.LoopMode = AnimationLoopMode::Stop;
-  MenuTransition.DurationIn = MenuTransitionDuration;
-  MenuTransition.DurationOut = MenuTransitionDuration;
-
   TitleFade.Direction = AnimationDirection::In;
   TitleFade.LoopMode = AnimationLoopMode::Stop;
   TitleFade.DurationIn = TitleFadeInDuration;
@@ -105,24 +101,17 @@ void ClearListMenu::Render() {
     Renderer->DrawSprite(MenuTitleText, LeftTitlePos);
   }
 
-  float yOffset = 0;
-  if (MenuTransition.Progress > 0.22f) {
-    if (MenuTransition.Progress < 0.73f) {
-      // Approximated function from the original, another mess
-      yOffset = glm::mix(
-          -Profile::DesignHeight, 0.0f,
-          1.00397f * std::sin(3.97161f - 3.26438f * MenuTransition.Progress) -
-              0.00295643f);
-    }
-    Renderer->DrawSprite(ClearListLabel,
-                         glm::vec2(LabelPosition.x, LabelPosition.y + yOffset));
-    DrawPlayTime(yOffset);
-    DrawEndingCount(yOffset);
-    DrawTIPSCount(yOffset);
-    DrawAlbumCompletion(yOffset);
-    DrawEndingTree(yOffset);
-    DrawButtonPrompt();
-  }
+  if (MenuTransition.Progress < 0.22f) return;
+  float yOffset = MenuTransition.GetPageOffset().y;
+
+  Renderer->DrawSprite(ClearListLabel,
+                       glm::vec2(LabelPosition.x, LabelPosition.y + yOffset));
+  DrawPlayTime(yOffset);
+  DrawEndingCount(yOffset);
+  DrawTIPSCount(yOffset);
+  DrawAlbumCompletion(yOffset);
+  DrawEndingTree(yOffset);
+  DrawButtonPrompt();
 }
 
 void ClearListMenu::Update(float dt) {

--- a/src/games/chlcc/clearlistmenu.h
+++ b/src/games/chlcc/clearlistmenu.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "animations/menutransition.h"
 #include "../../ui/menu.h"
 #include "../../ui/widgets/group.h"
 #include "../../ui/widgets/label.h"
@@ -33,7 +34,7 @@ class ClearListMenu : public Menu {
 
   void UpdateTitles();
 
-  Animation MenuTransition;
+  MenuTransitionAnimation MenuTransition;
   Animation TitleFade;
   Animation FromSystemMenuTransition;
 

--- a/src/games/chlcc/moviemenu.h
+++ b/src/games/chlcc/moviemenu.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "animations/selectprompt.h"
+#include "animations/menutransition.h"
 #include "../../ui/menu.h"
 #include "../../ui/widgets/group.h"
 #include "../../ui/widgets/button.h"
@@ -32,15 +34,14 @@ class MovieMenu : public Menu {
   void DrawErin();
   void DrawRedBar();
   void DrawButtonPrompt();
-  void DrawSelectMovie(float yOffset);
   void UpdateTitles();
 
   void UpdateMovieEntries();
 
-  Animation MenuTransition;
   Animation TitleFade;
-  Animation SelectMovieTextFade;
   Animation FromSystemMenuTransition;
+  SelectPromptAnimation SelectAnimation;
+  MenuTransitionAnimation MenuTransition;
 
   glm::vec2 RedTitleLabelPos;
   glm::vec2 RightTitlePos;

--- a/src/games/chlcc/optionsmenu.h
+++ b/src/games/chlcc/optionsmenu.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "animations/menutransition.h"
+
 #include "../../ui/optionsmenu.h"
 #include "../../ui/widgets/group.h"
 #include "../../ui/widgets/button.h"
@@ -43,9 +45,7 @@ class OptionsMenu : public UI::OptionsMenu {
 
   Animation TitleFade;
   Animation FromSystemMenuTransition;
-
-  Animation ShowPageAnimation;
-  glm::vec2 ShowPageOffset{0.0f, 0.0f};
+  MenuTransitionAnimation ShowPageAnimation;
 
   size_t PreviousPage = 0;
 

--- a/src/games/chlcc/savemenu.h
+++ b/src/games/chlcc/savemenu.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "animations/selectprompt.h"
+#include "animations/menutransition.h"
 #include "../../ui/menu.h"
 #include "../../ui/savemenu.h"
 #include "../../ui/widgets/group.h"
@@ -34,7 +36,6 @@ class SaveMenu : public UI::SaveMenu {
   void DrawRedBar();
   void DrawPageNumber(float yOffset);
   void DrawButtonPrompt();
-  void DrawSelectData(float yOffset);
 
   void UpdateTitles();
 
@@ -47,10 +48,10 @@ class SaveMenu : public UI::SaveMenu {
   std::vector<Widgets::Group*> QuickSavePages;
   std::vector<Widgets::Group*>* SavePages;
   Widgets::Group* MainItems;
-  Animation MenuTransition;
   Animation TitleFade;
-  Animation SelectDataTextFade;
   Animation FromSystemMenuTransition;
+  SelectPromptAnimation SelectAnimation;
+  MenuTransitionAnimation MenuTransition;
   SaveSystem::SaveType EntryType;
 
   glm::vec2 RedTitleLabelPos;

--- a/src/games/chlcc/systemmenu.h
+++ b/src/games/chlcc/systemmenu.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "animations/selectprompt.h"
+#include "animations/menutransition.h"
 #include <optional>
 #include "../../ui/menu.h"
 #include "../../ui/savemenu.h"
@@ -26,7 +28,6 @@ class SystemMenu : public Menu {
   void UpdateTitles();
   void DrawRedBar();
   void DrawButtonPrompt();
-  void DrawSelectMenu(float yOffset);
   void DrawRunningSelectedLabel(float offsetY);
   void UpdateRunningSelectedLabel(float dt);
   void UpdateSmoothSelection(float dt);
@@ -45,6 +46,11 @@ class SystemMenu : public Menu {
     ReturnTitle
   };
 
+  Widgets::Group* MainItems;
+  Animation TitleFade;
+  SelectPromptAnimation SelectAnimation;
+  MenuTransitionAnimation ShowMenu;
+
   float CurrentRunningPosition = 0.0f;
   float SelectionOffsetY = 0.0f;
   int IndexOfActiveButton = 0;
@@ -52,11 +58,6 @@ class SystemMenu : public Menu {
   glm::vec2 RedTitleLabelPos;
   glm::vec2 RightTitlePos;
   glm::vec2 LeftTitlePos;
-
-  Widgets::Group* MainItems;
-  Animation MenuTransition;
-  Animation TitleFade;
-  Animation MenuLoop;
 };
 
 }  // namespace CHLCC

--- a/src/games/chlcc/tipsmenu.h
+++ b/src/games/chlcc/tipsmenu.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "animations/selectprompt.h"
+#include "animations/menutransition.h"
 #include "../../ui/tipsmenu.h"
 #include "../../ui/widgets/group.h"
 #include "../../ui/widgets/button.h"
@@ -37,13 +39,13 @@ class TipsMenu : public UI::TipsMenu {
   void DrawRedBar();
   void DrawTipsTree();
   void DrawButtonPrompt();
-  void DrawSelectWord();
   void UpdateTitles();
   void HandlePageChange(Widget* cur, Widget* next);
 
   Animation TitleFade;
   Animation FromSystemMenuTransition;
-  Animation SelectWordAnimation;
+  SelectPromptAnimation SelectAnimation;
+  MenuTransitionAnimation MenuTransition;
 
   glm::vec2 RedTitleLabelPos;
   glm::vec2 RightTitlePos;
@@ -58,8 +60,6 @@ class TipsMenu : public UI::TipsMenu {
   Widgets::Label* TotalPages;
   std::vector<uint16_t> CategoryStringBuffer;
   std::optional<Widgets::Scrollbar> TipsEntriesScrollbar;
-
-  glm::vec2 AnimationOffset;
 };
 
 }  // namespace CHLCC

--- a/src/games/chlcc/trophymenu.cpp
+++ b/src/games/chlcc/trophymenu.cpp
@@ -23,6 +23,7 @@ namespace CHLCC {
 using namespace Impacto::Profile::TrophyMenu;
 using namespace Impacto::Profile::CHLCC::TrophyMenu;
 using namespace Impacto::Profile::ScriptVars;
+using namespace Impacto::Profile::GameSpecific;
 
 using namespace Impacto::Vm::Interface;
 
@@ -30,10 +31,6 @@ using namespace Impacto::UI::Widgets;
 using namespace Impacto::UI::Widgets::CHLCC;
 
 TrophyMenu::TrophyMenu() {
-  MenuTransition.Direction = AnimationDirection::In;
-  MenuTransition.LoopMode = AnimationLoopMode::Stop;
-  MenuTransition.SetDuration(MenuTransitionDuration);
-
   TitleFade.Direction = AnimationDirection::In;
   TitleFade.LoopMode = AnimationLoopMode::Stop;
   TitleFade.DurationIn = TitleFadeInDuration;
@@ -136,44 +133,32 @@ void TrophyMenu::Render() {
       RectF(0.0f, 0.0f, Profile::DesignWidth, Profile::DesignHeight),
       glm::vec4(tint, alpha));
 
-  const float startProgress =
-      ShowPageAnimationStartTime / MenuTransitionDuration;
-  const float endProgress =
-      startProgress + ShowPageAnimationDuration / MenuTransitionDuration;
+  if (MenuTransition.Progress < 0.22f) return;
 
-  if (startProgress < MenuTransition.Progress &&
-      MenuTransition.Progress < endProgress) {
-    const float progress = (MenuTransition.Progress - startProgress) /
-                           (endProgress - startProgress);
-    const float angle = progress * std::numbers::pi_v<float> * 0.5f;
-
-    Offset = {0.0f, (std::sin(angle) - 1.0f) * Profile::DesignHeight};
-  } else if (MenuTransition.Progress <= startProgress) {
-    Offset = {0.0f, -Profile::DesignHeight};
-  }
+  glm::vec2 offset = MenuTransition.GetPageOffset();
 
   DrawButtonPrompt();
 
-  TrophyCountHintLabel.Move(Offset);
+  TrophyCountHintLabel.Move(offset);
   TrophyCountHintLabel.Render();
-  TrophyCountHintLabel.Move(-Offset);
+  TrophyCountHintLabel.Move(-offset);
 
-  Renderer->DrawSprite(PlatinumTrophySprite, Offset + PlatinumTrophyPos);
-  Renderer->DrawSprite(GoldTrophySprite, Offset + GoldTrophyPos);
-  Renderer->DrawSprite(SilverTrophySprite, Offset + SilverTrophyPos);
-  Renderer->DrawSprite(BronzeTrophySprite, Offset + BronzeTrophyPos);
+  Renderer->DrawSprite(PlatinumTrophySprite, offset + PlatinumTrophyPos);
+  Renderer->DrawSprite(GoldTrophySprite, offset + GoldTrophyPos);
+  Renderer->DrawSprite(SilverTrophySprite, offset + SilverTrophyPos);
+  Renderer->DrawSprite(BronzeTrophySprite, offset + BronzeTrophyPos);
 
-  Renderer->DrawSprite(TrophyPageCtBoxSprite, Offset + TrophyPageCtPos);
-  Renderer->DrawSprite(PageNums[CurrentPage + 1], Offset + CurrentPageNumPos);
-  Renderer->DrawSprite(PageNumSeparatorSlash, Offset + PageNumSeparatorPos);
+  Renderer->DrawSprite(TrophyPageCtBoxSprite, offset + TrophyPageCtPos);
+  Renderer->DrawSprite(PageNums[CurrentPage + 1], offset + CurrentPageNumPos);
+  Renderer->DrawSprite(PageNumSeparatorSlash, offset + PageNumSeparatorPos);
   Renderer->DrawSprite(ReachablePageNums[MaxTrophyPages],
-                       Offset + MaxPageNumPos);
+                       offset + MaxPageNumPos);
 
-  MainItems[CurrentPage].Move(Offset);
+  MainItems[CurrentPage].Move(offset);
   MainItems[CurrentPage].Render();
-  MainItems[CurrentPage].Move(-Offset);
+  MainItems[CurrentPage].Move(-offset);
 
-  Renderer->DrawSprite(TrophyEntriesBorderSprite, Offset);
+  Renderer->DrawSprite(TrophyEntriesBorderSprite, offset);
 }
 
 void TrophyMenu::UpdateInput(float dt) {

--- a/src/games/chlcc/trophymenu.h
+++ b/src/games/chlcc/trophymenu.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "animations/menutransition.h"
 #include "../../ui/menu.h"
 #include "../../ui/widgets/group.h"
 #include "../../ui/widgets/button.h"
@@ -29,7 +30,7 @@ class TrophyMenu : public UI::Menu {
   void DrawButtonPrompt();
   void UpdateTitles();
 
-  Animation MenuTransition;
+  MenuTransitionAnimation MenuTransition;
   Animation TitleFade;
   Animation FromSystemMenuTransition;
 
@@ -42,7 +43,6 @@ class TrophyMenu : public UI::Menu {
           this, this, this, this, this, this, this, this, this};
   int CurrentPage = 0;
 
-  glm::vec2 Offset;
   Impacto::UI::Widgets::Label TrophyCountHintLabel;
 };
 

--- a/src/profile/games/chlcc/albummenu.cpp
+++ b/src/profile/games/chlcc/albummenu.cpp
@@ -10,7 +10,6 @@ namespace CHLCC {
 namespace AlbumMenu {
 
 void Configure() {
-  MenuTransitionDuration = EnsureGetMember<float>("TransitionDuration");
   BackgroundColor = EnsureGetMember<uint32_t>("BackgroundColor");
   CircleSprite = EnsureGetMember<Sprite>("CircleSprite");
   CircleStartPosition = EnsureGetMember<glm::vec2>("CircleStartPosition");
@@ -54,8 +53,11 @@ void Configure() {
   GetMemberArray<Sprite>(ReachablePageNums, 10, "ReachablePageNums");
   ButtonGuide = EnsureGetMember<Sprite>("ButtonGuide");
   ButtonGuidePos = EnsureGetMember<glm::vec2>("ButtonGuidePos");
-  GetMemberArray<Sprite>(SelectData, 10, "SelectData");
-  GetMemberArray<glm::vec2>(SelectDataPos, 10, "SelectDataPos");
+  SelectDataSprites = GetMemberVector<Sprite>("SelectDataSprites");
+  SelectDataPos = GetMemberVector<glm::vec2>("SelectDataPos");
+  if (SelectDataSprites.size() != SelectDataPos.size()) {
+    throw std::runtime_error("Related arrays have mismatching sizes");
+  }
   AlbumMenuTitle = EnsureGetMember<Sprite>("AlbumMenuTitle");
   AlbumMenuTitleRightPos = EnsureGetMember<glm::vec2>("AlbumMenuTitleRightPos");
   AlbumMenuTitleLeftPos = EnsureGetMember<glm::vec2>("AlbumMenuTitleLeftPos");

--- a/src/profile/games/chlcc/albummenu.h
+++ b/src/profile/games/chlcc/albummenu.h
@@ -7,7 +7,6 @@ namespace Profile {
 namespace CHLCC {
 namespace AlbumMenu {
 
-inline float MenuTransitionDuration;
 inline uint32_t BackgroundColor;
 inline Sprite CircleSprite;
 inline glm::vec2 CircleStartPosition;
@@ -50,8 +49,8 @@ inline glm::vec2 PageNumSeparatorSlashPos;
 inline Sprite ReachablePageNums[10];
 inline Sprite ButtonGuide;
 inline glm::vec2 ButtonGuidePos;
-inline Sprite SelectData[10];
-inline glm::vec2 SelectDataPos[10];
+inline std::vector<Sprite> SelectDataSprites;
+inline std::vector<glm::vec2> SelectDataPos;
 inline Sprite AlbumMenuTitle;
 inline glm::vec2 AlbumMenuTitleRightPos;
 inline glm::vec2 AlbumMenuTitleLeftPos;

--- a/src/profile/games/chlcc/backlogmenu.cpp
+++ b/src/profile/games/chlcc/backlogmenu.cpp
@@ -9,7 +9,6 @@ namespace CHLCC {
 namespace BacklogMenu {
 
 void Configure() {
-  TransitionDuration = EnsureGetMember<float>("TransitionDuration");
   BackgroundColor = EnsureGetMember<uint32_t>("BackgroundColor");
   CircleSprite = EnsureGetMember<Sprite>("CircleSprite");
   CircleStartPosition = EnsureGetMember<glm::vec2>("CircleStartPosition");

--- a/src/profile/games/chlcc/backlogmenu.h
+++ b/src/profile/games/chlcc/backlogmenu.h
@@ -9,7 +9,6 @@ namespace BacklogMenu {
 
 void Configure();
 
-inline float TransitionDuration;
 inline uint32_t BackgroundColor;
 inline Sprite CircleSprite;
 inline glm::vec2 CircleStartPosition;

--- a/src/profile/games/chlcc/clearlistmenu.cpp
+++ b/src/profile/games/chlcc/clearlistmenu.cpp
@@ -10,7 +10,6 @@ namespace CHLCC {
 namespace ClearListMenu {
 
 void Configure() {
-  MenuTransitionDuration = EnsureGetMember<float>("TransitionDuration");
   BackgroundColor = EnsureGetMember<uint32_t>("BackgroundColor");
   CircleSprite = EnsureGetMember<Sprite>("CircleSprite");
   CircleStartPosition = EnsureGetMember<glm::vec2>("CircleStartPosition");

--- a/src/profile/games/chlcc/clearlistmenu.h
+++ b/src/profile/games/chlcc/clearlistmenu.h
@@ -9,7 +9,6 @@ namespace ClearListMenu {
 
 int constexpr Endings = 8;
 
-inline float MenuTransitionDuration;
 inline uint32_t BackgroundColor;
 inline Sprite CircleSprite;
 inline glm::vec2 CircleStartPosition;

--- a/src/profile/games/chlcc/moviemenu.cpp
+++ b/src/profile/games/chlcc/moviemenu.cpp
@@ -11,7 +11,6 @@ namespace CHLCC {
 namespace MovieMenu {
 
 void Configure() {
-  MenuTransitionDuration = EnsureGetMember<float>("TransitionDuration");
   BackgroundColor = EnsureGetMember<uint32_t>("BackgroundColor");
   CircleSprite = EnsureGetMember<Sprite>("CircleSprite");
   CircleStartPosition = EnsureGetMember<glm::vec2>("CircleStartPosition");
@@ -38,9 +37,11 @@ void Configure() {
       EnsureGetMember<SpriteAnimationDef>("SelectedMovieAnimation");
   SelectedMovieYellowDot = EnsureGetMember<Sprite>("SelectedMovieYellowDot");
 
-  SelectMovieFadeDuration = EnsureGetMember<float>("SelectMovieFadeDuration");
-  GetMemberArray<Sprite>(SelectMovie, 11, "SelectMovie");
-  GetMemberArray<glm::vec2>(SelectMoviePos, 11, "SelectMoviePos");
+  SelectMovie = GetMemberVector<Sprite>("SelectMovie");
+  SelectMoviePos = GetMemberVector<glm::vec2>("SelectMoviePos");
+  if (SelectMovie.size() != SelectMoviePos.size()) {
+    throw std::runtime_error("Related arrays have mismatching sizes");
+  }
   LabelPosition = EnsureGetMember<glm::vec2>("LabelPosition");
   MovieLabel = EnsureGetMember<Sprite>("MovieLabel");
   ListPosition = EnsureGetMember<glm::vec2>("ListPosition");

--- a/src/profile/games/chlcc/moviemenu.h
+++ b/src/profile/games/chlcc/moviemenu.h
@@ -10,7 +10,6 @@ namespace MovieMenu {
 
 int constexpr Movies = 10;
 
-inline float MenuTransitionDuration;
 inline uint32_t BackgroundColor;
 inline Sprite CircleSprite;
 inline glm::vec2 CircleStartPosition;
@@ -37,8 +36,8 @@ inline SpriteAnimationDef SelectedMovieAnimation;
 inline Sprite SelectedMovieYellowDot;
 
 inline float SelectMovieFadeDuration;
-inline Sprite SelectMovie[11];
-inline glm::vec2 SelectMoviePos[11];
+inline std::vector<Sprite> SelectMovie;
+inline std::vector<glm::vec2> SelectMoviePos;
 inline glm::vec2 LabelPosition;
 inline Sprite MovieLabel;
 inline Sprite MovieList;

--- a/src/profile/games/chlcc/musicmenu.cpp
+++ b/src/profile/games/chlcc/musicmenu.cpp
@@ -10,7 +10,6 @@ namespace CHLCC {
 namespace MusicMenu {
 
 void Configure() {
-  MenuTransitionDuration = EnsureGetMember<float>("TransitionDuration");
   BackgroundColor = EnsureGetMember<uint32_t>("BackgroundColor");
   CircleSprite = EnsureGetMember<Sprite>("CircleSprite");
   CircleStartPosition = EnsureGetMember<glm::vec2>("CircleStartPosition");
@@ -60,12 +59,18 @@ void Configure() {
   HighlightStarRelativePos =
       EnsureGetMember<glm::vec2>("HighlightStarRelativePos");
   GetMemberArray<int>(Playlist, MusicTrackCount, "Playlist");
-  GetMemberArray<Sprite>(SelectSound, 11, "SelectSound");
-  GetMemberArray<glm::vec2>(SelectSoundPos, 11, "SelectSoundPos");
+  SelectSoundSprites = GetMemberVector<Sprite>("SelectSoundSprites");
+  SelectSoundPos = GetMemberVector<glm::vec2>("SelectSoundPos");
+  if (SelectSoundSprites.size() != SelectSoundPos.size()) {
+    throw std::runtime_error("Related arrays have mismatching sizes");
+  }
 
   auto drawType = Game::DrawComponentType::_from_integral_unchecked(
       EnsureGetMember<uint8_t>("DrawType"));
-
+  ScrollThumbSprite = EnsureGetMember<Sprite>("ScrollThumb");
+  ScrollbarPosition = EnsureGetMember<glm::vec2>("ScrollbarPosition");
+  TrackListBounds = EnsureGetMember<RectF>("TrackListBounds");
+  ScrollTrackBounds = EnsureGetMember<glm::vec2>("ScrollTrackBounds");
   UI::Menus[drawType].push_back(new UI::CHLCC::MusicMenu());
 }
 

--- a/src/profile/games/chlcc/musicmenu.h
+++ b/src/profile/games/chlcc/musicmenu.h
@@ -12,7 +12,6 @@ int inline constexpr MusicTrackCount = 45;
 int inline constexpr VisibleItemsPerPage = 16;
 int inline constexpr SelectableItemsPerPage = 15;
 
-inline float MenuTransitionDuration;
 inline uint32_t BackgroundColor;
 inline Sprite CircleSprite;
 inline glm::vec2 CircleStartPosition;
@@ -57,10 +56,14 @@ inline float SoundLibraryTitleAngle;
 inline Sprite HighlightStar;
 inline glm::vec2 HighlightStarRelativePos;
 inline int Playlist[MusicTrackCount];
-inline Sprite SelectSound[11];
-inline glm::vec2 SelectSoundPos[11];
+inline std::vector<Sprite> SelectSoundSprites;
+inline std::vector<glm::vec2> SelectSoundPos;
 inline glm::vec2 ButtonPromptPosition;
 inline Sprite ButtonPromptSprite;
+inline Sprite ScrollThumbSprite;
+inline glm::vec2 ScrollbarPosition;
+inline glm::vec2 ScrollTrackBounds;
+inline RectF TrackListBounds;
 
 void Configure();
 

--- a/src/profile/games/chlcc/savemenu.cpp
+++ b/src/profile/games/chlcc/savemenu.cpp
@@ -73,10 +73,12 @@ void Configure() {
   ButtonPromptPosition = EnsureGetMember<glm::vec2>("ButtonPromptPosition");
   ButtonPromptSprite = EnsureGetMember<Sprite>("ButtonPrompt");
   SelectDataFadeDuration = EnsureGetMember<float>("SelectDataFadeDuration");
-  // 10 letters in "SELECT DATA"
-  GetMemberArray<glm::vec2>(SelectDataTextPositions, 10,
-                            "SelectDataTextPositions");
-  GetMemberArray<Sprite>(SelectDataTextSprites, 10, "SelectDataText");
+  SelectDataTextPositions =
+      GetMemberVector<glm::vec2>("SelectDataTextPositions");
+  SelectDataTextSprites = GetMemberVector<Sprite>("SelectDataText");
+  if (SelectDataTextPositions.size() != SelectDataTextSprites.size()) {
+    throw std::runtime_error("Related arrays have mismatching sizes");
+  }
 
   EntryNumberHintTextRelativePos =
       EnsureGetMember<glm::vec2>("EntryNumberHintTextRelativePos");

--- a/src/profile/games/chlcc/savemenu.h
+++ b/src/profile/games/chlcc/savemenu.h
@@ -70,9 +70,8 @@ inline Sprite MaxPageNumSprite;
 inline glm::vec2 ButtonPromptPosition;
 inline Sprite ButtonPromptSprite;
 inline float SelectDataFadeDuration;
-// 10 letters in "SELECT DATA"
-inline glm::vec2 SelectDataTextPositions[10];
-inline Sprite SelectDataTextSprites[10];
+inline std::vector<glm::vec2> SelectDataTextPositions;
+inline std::vector<Sprite> SelectDataTextSprites;
 
 inline glm::vec2 EntryNumberHintTextRelativePos;
 inline glm::vec2 EntryNumberTextRelativePos;

--- a/src/profile/games/chlcc/systemmenu.cpp
+++ b/src/profile/games/chlcc/systemmenu.cpp
@@ -46,11 +46,14 @@ void Configure() {
   MenuSelection = EnsureGetMember<Sprite>("SystemMenuSelection");
   MenuSelectionPosition =
       EnsureGetMember<glm::vec2>("SystemMenuSelectionPosition");
-  SelectMenuHeaderCount = EnsureGetMember<int>("SelectMenuSpritesCount");
-  GetMemberArray<Sprite>(SelectMenuHeader, SelectMenuHeaderCount,
-                         "SelectMenuSprites");
-  GetMemberArray<glm::vec2>(SelectMenuHeaderPositions, SelectMenuHeaderCount,
-                            "SelectMenuTextPositions");
+
+  SelectMenuHeader = GetMemberVector<Sprite>("SelectMenuSprites");
+  SelectMenuHeaderPositions =
+      GetMemberVector<glm::vec2>("SelectMenuTextPositions");
+  if (SelectMenuHeader.size() != SelectMenuHeaderPositions.size()) {
+    throw std::runtime_error("Related arrays have mismatching sizes");
+  }
+
   MenuLoopDuration = EnsureGetMember<float>("MenuLoopDuration");
   HoverLerpSpeed = EnsureGetMember<float>("MenuHoverLerpSpeed");
   MenuRunningSelectedLabel =

--- a/src/profile/games/chlcc/systemmenu.h
+++ b/src/profile/games/chlcc/systemmenu.h
@@ -7,7 +7,6 @@ namespace Profile {
 namespace CHLCC {
 namespace SystemMenu {
 constexpr int MenuEntriesNumMax = 9;
-constexpr int SelectMenuTextMax = 10;
 
 inline uint32_t BackgroundColor;
 inline Sprite BackgroundFilter;
@@ -37,8 +36,8 @@ inline glm::vec2 MenuSelectionDotPosition;
 inline float MenuSelectionDotMultiplier;
 inline Sprite MenuSelection;
 inline glm::vec2 MenuSelectionPosition;
-inline Sprite SelectMenuHeader[SelectMenuTextMax];
-inline glm::vec2 SelectMenuHeaderPositions[SelectMenuTextMax];
+inline std::vector<Sprite> SelectMenuHeader;
+inline std::vector<glm::vec2> SelectMenuHeaderPositions;
 inline int SelectMenuHeaderCount;
 inline Sprite MenuRunningSelectedLabel;
 inline glm::vec2 MenuRunningSelectedLabelPosition;

--- a/src/profile/games/chlcc/tipsmenu.cpp
+++ b/src/profile/games/chlcc/tipsmenu.cpp
@@ -14,7 +14,6 @@ namespace CHLCC {
 namespace TipsMenu {
 
 void Configure() {
-  MenuTransitionDuration = EnsureGetMember<float>("TransitionDuration");
   BackgroundColor = EnsureGetMember<uint32_t>("BackgroundColor");
   CircleSprite = EnsureGetMember<Sprite>("CircleSprite");
   CircleStartPosition = EnsureGetMember<glm::vec2>("CircleStartPosition");
@@ -86,6 +85,7 @@ void Configure() {
       EnsureGetMember<RectF>("PronounciationInitialBounds");
 
   TipsListBounds = EnsureGetMember<RectF>("TipsListBounds");
+  TipScrollbarPos = EnsureGetMember<glm::vec2>("TipScrollbarPos");
   TipsListRenderBounds = EnsureGetMember<RectF>("TipsListRenderBounds");
 
   TipsEntryHighlightBar =
@@ -114,8 +114,9 @@ void Configure() {
 
   SelectWordSprites = GetMemberVector<Sprite>("SelectWordSprites");
   SelectWordPos = GetMemberVector<glm::vec2>("SelectWordPos");
-  SelectWordDuration = EnsureGetMember<float>("SelectWordDuration");
-  SelectWordInterval = EnsureGetMember<float>("SelectWordInterval");
+  if (SelectWordSprites.size() != SelectWordPos.size()) {
+    throw std::runtime_error("Related arrays have mismatching sizes");
+  }
 
   auto drawType = Game::DrawComponentType::_from_integral_unchecked(
       EnsureGetMember<uint8_t>("DrawType"));

--- a/src/profile/games/chlcc/tipsmenu.h
+++ b/src/profile/games/chlcc/tipsmenu.h
@@ -9,7 +9,6 @@ namespace TipsMenu {
 
 int constexpr inline MaxCategoryString = 5;
 
-inline float MenuTransitionDuration;
 inline uint32_t BackgroundColor;
 inline Sprite CircleSprite;
 inline glm::vec2 CircleStartPosition;
@@ -68,6 +67,7 @@ inline glm::vec2 TipsListNewDotOffset;
 inline RectF NameInitialBounds;
 inline RectF PronounciationInitialBounds;
 inline RectF TipsListBounds;
+inline glm::vec2 TipScrollbarPos;
 inline RectF TipsListRenderBounds;
 inline Sprite TipsEntryHighlightBar;
 inline Sprite TipsEntryHighlightDot;
@@ -91,8 +91,6 @@ inline Sprite PageSeparatorSprite;
 
 inline std::vector<Sprite> SelectWordSprites;
 inline std::vector<glm::vec2> SelectWordPos;
-inline float SelectWordDuration;
-inline float SelectWordInterval;
 
 void Configure();
 

--- a/src/profile/games/chlcc/trophymenu.cpp
+++ b/src/profile/games/chlcc/trophymenu.cpp
@@ -15,8 +15,6 @@ namespace CHLCC {
 namespace TrophyMenu {
 
 void Configure() {
-  MenuTransitionDuration = EnsureGetMember<float>("TransitionDuration");
-
   ShowPageAnimationStartTime =
       EnsureGetMember<float>("ShowPageAnimationStartTime");
   ShowPageAnimationDuration =

--- a/src/profile/games/chlcc/trophymenu.h
+++ b/src/profile/games/chlcc/trophymenu.h
@@ -9,8 +9,6 @@ namespace TrophyMenu {
 
 int constexpr inline MaxTrophyPages = 9;
 
-inline float MenuTransitionDuration;
-
 inline float ShowPageAnimationStartTime;
 inline float ShowPageAnimationDuration;
 

--- a/src/profile/ui/gamespecific.cpp
+++ b/src/profile/ui/gamespecific.cpp
@@ -36,6 +36,16 @@ void Configure() {
     BubbleSpriteSmall = EnsureGetMember<Sprite>("BubbleSpriteSmall");
     BubbleSpriteBig = EnsureGetMember<Sprite>("BubbleSpriteBig");
     BubbleFadeDuration = EnsureGetMember<float>("BubbleFadeDuration");
+
+    MenuSelectPromptDuration =
+        EnsureGetMember<float>("MenuSelectPromptDuration");
+    MenuSelectPromptInterval =
+        EnsureGetMember<float>("MenuSelectPromptInterval");
+    MenuTransitionDuration = EnsureGetMember<float>("MenuTransitionDuration");
+    ShowPageAnimationStartTime =
+        EnsureGetMember<float>("ShowPageAnimationStartTime");
+    ShowPageAnimationDuration =
+        EnsureGetMember<float>("ShowPageAnimationDuration");
   }
 
   Pop();

--- a/src/profile/ui/gamespecific.h
+++ b/src/profile/ui/gamespecific.h
@@ -18,6 +18,12 @@ inline uint8_t ButterflyFrameCount;
 inline float ButterflyFlapFrameDuration;
 inline float ButterflyFadeDuration;
 
+inline float MenuSelectPromptDuration;
+inline float MenuSelectPromptInterval;
+inline float MenuTransitionDuration;
+inline float ShowPageAnimationStartTime;
+inline float ShowPageAnimationDuration;
+
 inline Sprite BubbleSpriteSmall;
 inline Sprite BubbleSpriteBig;
 inline float BubbleFadeDuration;

--- a/src/ui/menu.h
+++ b/src/ui/menu.h
@@ -8,8 +8,8 @@
 namespace Impacto {
 namespace UI {
 
-enum MenuState { Hidden, Hiding, Showing, Shown };
-enum class InputRate { SingleTap, RepeatSlow, RepeatFast, Hold };
+enum MenuState : uint8_t { Hidden, Hiding, Showing, Shown };
+enum class InputRate : uint8_t { SingleTap, RepeatSlow, RepeatFast, Hold };
 
 class Menu {
  public:
@@ -21,17 +21,16 @@ class Menu {
 
   virtual void UpdateInput(float dt);
 
+  Menu* LastFocusedMenu = 0;
+  Widget* FocusStart[4] = {0, 0, 0, 0};
+  Widget* CurrentlyFocusedElement = 0;
+  InputRate InputConfig = InputRate::RepeatSlow;
   MenuState State = Hidden;
 
   bool IsFocused = false;
   bool ChoiceMade = false;
   bool AllowsScriptInput = true;
   uint8_t DrawType = Game::DrawComponentType::Main;
-
-  Menu* LastFocusedMenu = 0;
-  Widget* FocusStart[4] = {0, 0, 0, 0};
-  Widget* CurrentlyFocusedElement = 0;
-  InputRate InputConfig = InputRate::RepeatSlow;
 
  protected:
   void AdvanceFocus(FocusDirection dir);

--- a/src/ui/optionsmenu.h
+++ b/src/ui/optionsmenu.h
@@ -30,8 +30,6 @@ class OptionsMenu : public Menu {
 
   virtual void Highlight(Widget* toHighlight);
 
-  bool RememberLastPage = false;
-  bool RememberHighlightedEntries = false;
   std::vector<Widget*> HighlightedEntriesPerPage;
 
   Animation FadeAnimation;
@@ -40,6 +38,9 @@ class OptionsMenu : public Menu {
   std::vector<std::unique_ptr<Widgets::Group>> Pages;
 
   uint32_t PADinputButtonHoldMask;
+
+  bool RememberLastPage = false;
+  bool RememberHighlightedEntries = false;
 };
 
 }  // namespace UI

--- a/src/ui/widgets/chlcc/systemmessagebutton.cpp
+++ b/src/ui/widgets/chlcc/systemmessagebutton.cpp
@@ -60,7 +60,7 @@ void SystemMessageButton::SetText(std::vector<ProcessedTextGlyph> text,
   const glm::vec2 rightSize = RightHighlightSprite.ScaledBounds().GetSize();
   const float rightWidth = rightSize.x * (fontSize / rightSize.y);
 
-  LeftHighlightPos = {Bounds.X - leftWidth - 1.0f, Bounds.Y};
+  LeftHighlightPos = {Bounds.X - leftWidth - 0.5f, Bounds.Y};
   RightHighlightPos = {Bounds.X + TextWidth, Bounds.Y};
   HoverBounds = RectF(LeftHighlightPos.x, Bounds.Y,
                       TextWidth + leftWidth + rightWidth, fontSize);

--- a/src/ui/widgets/chlcc/trackselectbutton.cpp
+++ b/src/ui/widgets/chlcc/trackselectbutton.cpp
@@ -1,10 +1,12 @@
 #include "trackselectbutton.h"
 #include "../../../renderer/renderer.h"
+#include "../../../profile/games/chlcc/musicmenu.h"
 
 namespace Impacto {
 namespace UI {
 namespace Widgets {
 namespace CHLCC {
+using namespace Impacto::Profile::CHLCC::MusicMenu;
 
 TrackSelectButton::TrackSelectButton(int id, Sprite const &focused,
                                      glm::vec2 pos, glm::vec2 numOffset,
@@ -31,7 +33,10 @@ void TrackSelectButton::SetArtistText(Vm::BufferOffsetContext strAdr) {
 
 void TrackSelectButton::Render() {
   if (HasFocus) {
-    Renderer->DrawSprite(FocusedSprite, glm::vec2(0, Bounds.Y));
+    // adjusts sprite height to prevent visual bug tied to mouse support (1px of
+    // out of bounds highlight sprite can be visible)
+    RectF dest = RectF(0, Bounds.Y, FocusedSprite.ScaledWidth(), TrackOffset.y);
+    Renderer->DrawSprite(FocusedSprite, dest);
   }
 
   TrackNum.Render();

--- a/src/ui/widgets/scrollbar.cpp
+++ b/src/ui/widgets/scrollbar.cpp
@@ -190,8 +190,7 @@ void Scrollbar::Move(glm::vec2 relativePosition) {
 }
 
 void Scrollbar::ClampValue() {
-  float minValue = std::min(StartValue, EndValue);
-  float maxValue = std::max(StartValue, EndValue);
+  auto [minValue, maxValue] = std::minmax(StartValue, EndValue);
   *Value = std::clamp(*Value, minValue, maxValue);
 }
 

--- a/src/ui/widgets/scrollbar.h
+++ b/src/ui/widgets/scrollbar.h
@@ -11,6 +11,7 @@ enum ScrollbarDirection { SBDIR_VERTICAL, SBDIR_HORIZONTAL };
 
 class Scrollbar : public Widget {
  public:
+  Scrollbar() = default;
   Scrollbar(int id, glm::vec2 pos, float start, float end, float* value,
             ScrollbarDirection dir, glm::vec2 trackBounds);
   Scrollbar(int id, glm::vec2 pos, float start, float end, float* value,
@@ -42,6 +43,7 @@ class Scrollbar : public Widget {
   };
 
   RectF GetTrackBounds() const { return TrackBounds; }
+  bool IsScrollHeld() const { return ScrollHeld; }
 
   int Id;
   ScrollbarDirection Direction;


### PR DESCRIPTION
CHLCC: Menus Polish

Sound:
- Add scrollbar support
- Add click support for switching playback mode
- Fix misaligned elements ("Select ***" text and Menu Title text mostly) and animations

Tips:
- Start with right page
- Fix sprites bounds

Sound, Movie, CG:
- Add "Select ***" animation based on the Tip's menu "Select Word" animation

Sound, Movie, CG, Save/Load:
- Simplify sprite loading for "Select ***" in .lua

Tips, Save/Load, Title, Sound, Movie, CG:
- Use one implementation for all "Select ***" animation (via composition)

Backlog, Clear, Tips, Save/Load, Title, Sound, Movie, CG, Options, Trophy:
- Use one implementation for "Show Menu" animation taken from Options menu (via composition)

Bonus:
- Shave off 16 bytes of every Animation (Widget has Animation field)
- Shave off 8 bytes of every Menu