### PR TITLE
Fix mosaic transition bug on iGPU

### DIFF
--- a/src/shaders/opengl/GaussianBlur_frag.glsl
+++ b/src/shaders/opengl/GaussianBlur_frag.glsl
@@ -45,8 +45,8 @@ void main() {
         float weight = interpolateWeight(float(i) / weightDistance);
         totalWeight += weight * 2.0;
 
-        color += weight * texture2D(ColorMap, uv + normalizedOffset * i);
-        color += weight * texture2D(ColorMap, uv - normalizedOffset * i);
+        color += weight * texture(ColorMap, uv + normalizedOffset * i);
+        color += weight * texture(ColorMap, uv - normalizedOffset * i);
     }
     color /= totalWeight;
 

--- a/src/shaders/opengl/Mosaic_frag.glsl
+++ b/src/shaders/opengl/Mosaic_frag.glsl
@@ -11,7 +11,7 @@ void main() {
     color = tint;
 
     if (TileSize <= 1.0) {
-        color *= texture2D(ColorMap, uv);
+        color *= texture(ColorMap, uv);
         return;
     }
 
@@ -19,5 +19,5 @@ void main() {
     vec2 tileCoord = floor(uv / tileUvSize);
     vec2 tileCenterPos = (tileCoord + vec2(0.5)) * tileUvSize;
 
-    color *= texture2D(ColorMap, tileCenterPos);
+    color *= texture(ColorMap, tileCenterPos);
 }


### PR DESCRIPTION
Mosaic transition animation bugs on iGPU due to `texture2D` function call. Fixed by using `texture` function call instead.