### PR TITLE
CHLCC: Updated musicmenu to work with BGM Flags. Issue 337.

### DIFF
--- a/src/games/chlcc/musicmenu.cpp
+++ b/src/games/chlcc/musicmenu.cpp
@@ -513,7 +513,7 @@ void MusicMenu::UpdateEntries() {
     auto button = static_cast<Widgets::CHLCC::TrackSelectButton*>(
         MainItems->Children[idx]);
 
-    if (!SaveSystem::GetBgmFlag((int)idx)) {
+    if (!SaveSystem::GetBgmFlag(Playlist[button->Id])) {
       button->SetTrackText(Vm::ScriptGetTextTableStrAddress(0, 15));
       continue;
     }


### PR DESCRIPTION
Changed playlist at the end to have 70 instead of 71 in extramenus.lua. Changed bgm checking to work with internal flags, not arbitrary ids.