### PR TITLE
Dock/taskbar icon not changing dynamically per game on Windows fix.

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -125,6 +125,8 @@ static void Init() {
     Effects::Blur.Init();
   }
 
+  SetWindowIcon(Window->SDLWindow);
+
   if (Profile::GameFeatures & GameFeature::ModelViewer) {
     ModelViewer::Init();
   }

--- a/src/renderer/dx9/window.cpp
+++ b/src/renderer/dx9/window.cpp
@@ -95,8 +95,6 @@ void DirectX9Window::Init() {
   ImpLog(LogLevel::Debug, LogChannel::General,
          "Window size (screen coords): {:d} x {:d}\n", WindowWidth,
          WindowHeight);
-
-  SetWindowIcon(SDLWindow);
 }
 
 void DirectX9Window::SetDimensions(int width, int height, int msaa,

--- a/src/renderer/opengl/window.cpp
+++ b/src/renderer/opengl/window.cpp
@@ -205,8 +205,6 @@ void GLWindow::Init() {
          "Window size (screen coords): {:d} x {:d}\n", WindowWidth,
          WindowHeight);
 
-  SetWindowIcon(SDLWindow);
-
   bool gladOk;
   if (ActualGraphicsApi == GfxApi_GL) {
     gladOk = gladLoadGLLoader(SDL_GL_GetProcAddress);

--- a/src/renderer/vulkan/window.cpp
+++ b/src/renderer/vulkan/window.cpp
@@ -92,8 +92,6 @@ void VulkanWindow::Init() {
   ImpLog(LogLevel::Debug, LogChannel::General,
          "Window size (screen coords): {:d} x {:d}\n", WindowWidth,
          WindowHeight);
-
-  SetWindowIcon(SDLWindow);
 }
 
 void VulkanWindow::SetDimensions(int width, int height, int msaa,


### PR DESCRIPTION
This PR will fix dock/taskbar icon not changing dynamically per game on Windows. (part of Issue #331).