### PR TITLE
Dock/taskbar icon not changing dynamically per game on some Linux DE's fix.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ set(Impacto_Src
         src/util.cpp
         src/workqueue.cpp
         src/game.cpp
+        src/linuxdesktop.cpp
         src/mem.cpp
         src/modelviewer.cpp
         src/characterviewer.cpp
@@ -356,6 +357,7 @@ set(Impacto_Header
         src/util.h
         src/workqueue.h
         src/game.h
+        src/linuxdesktop.h
         src/mem.h
         src/modelviewer.h
         src/characterviewer.h

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -33,6 +33,10 @@
 #include "effects/blur.h"
 #include "effects/mosaic.h"
 
+#ifdef __linux__
+#include "linuxdesktop.h"
+#endif
+
 #include "profile/profile.h"
 #include "profile/game.h"
 #include "profile/sprites.h"
@@ -83,6 +87,10 @@ static void Init() {
     io.ConfigFlags |= ImGuiConfigFlags_ViewportsEnable;
     io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;
   }
+#endif
+
+#ifdef __linux__
+  LinuxDesktop::SetWMClassHints(Profile::CurrentProfileName);
 #endif
 
   InitRenderer();
@@ -170,6 +178,7 @@ static void Init() {
 }
 
 void InitFromProfile(std::string const& name) {
+  Profile::CurrentProfileName = name;
   Profile::MakeLuaProfile(name);
   Init();
 }

--- a/src/linuxdesktop.cpp
+++ b/src/linuxdesktop.cpp
@@ -1,0 +1,28 @@
+#ifdef __linux__
+#include "linuxdesktop.h"
+#include "log.h"
+#include <SDL.h>
+#include <cstdlib>
+
+namespace Impacto {
+namespace LinuxDesktop {
+
+void SetWMClassHints(const std::string& profileName) {
+  const std::string& wmClass = profileName;
+
+  setenv("SDL_VIDEO_X11_WMCLASS", wmClass.c_str(), 1);
+  setenv("SDL_VIDEO_WAYLAND_WMCLASS", wmClass.c_str(), 1);
+  setenv("SDL_APP_ID", wmClass.c_str(), 1);
+
+  SDL_SetHintWithPriority("SDL_APP_ID", wmClass.c_str(), SDL_HINT_OVERRIDE);
+  SDL_SetHintWithPriority("SDL_VIDEO_X11_WMCLASS", wmClass.c_str(),
+                          SDL_HINT_OVERRIDE);
+  SDL_SetHintWithPriority("SDL_VIDEO_WAYLAND_WMCLASS", wmClass.c_str(),
+                          SDL_HINT_OVERRIDE);
+
+  ImpLog(LogLevel::Info, LogChannel::General, "Set WM_CLASS: {:s}\n", wmClass);
+}
+
+}  // namespace LinuxDesktop
+}  // namespace Impacto
+#endif

--- a/src/linuxdesktop.h
+++ b/src/linuxdesktop.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#ifdef __linux__
+#include <string>
+
+namespace Impacto {
+namespace LinuxDesktop {
+
+void SetWMClassHints(const std::string& profileName);
+
+}  // namespace LinuxDesktop
+}  // namespace Impacto
+#endif

--- a/src/profile/game.h
+++ b/src/profile/game.h
@@ -21,6 +21,8 @@ inline std::optional<std::string> WindowIconPath;
 inline std::optional<std::string> CursorArrowPath;
 inline std::optional<std::string> CursorPointerPath;
 
+inline std::string CurrentProfileName;
+
 inline bool LayFileBigEndian;
 inline bool CharaIsMvl;
 


### PR DESCRIPTION
This PR will fix dock/taskbar icon not changing dynamically per game on some Linux DE's. (added support for .desktop files.) (Issue #331). 
Example on Ubuntu:
<img width="1285" height="808" alt="{7628BB6F-DE12-4907-A998-95E40B3B0C07}" src="https://github.com/user-attachments/assets/256aa7f2-bbf5-41a7-841f-ec81be923152" />

Example on Manjaro:
<img width="2356" height="1277" alt="{8C8FC4C5-C0F7-400C-AF8B-76877BAEF4B5}" src="https://github.com/user-attachments/assets/84798980-5dd7-4a01-91a9-e896c0f7c18d" />
