### PR TITLE
[CCLCC] Movie disk can be hovered during movie playback fix.

### DIFF
--- a/src/games/cclcc/librarymenu.cpp
+++ b/src/games/cclcc/librarymenu.cpp
@@ -190,7 +190,7 @@ void LibraryMenu::Update(float dt) {
   FadeAnimation.Update(dt);
   UI::AlbumMenuPtr->Update(dt);
   UI::MusicMenuPtr->Update(dt);
-  UI::MovieMenuPtr->Update(dt);
+  if (!moviePlaying) UI::MovieMenuPtr->Update(dt);
   ButtonBlinkAnimation.Update(dt);
   if (!moviePlaying && !cgViewerActive) MainItems.Update(dt);
 


### PR DESCRIPTION
This PR will fix CCLCC bug when user can hover Movie disk during Movie playback (cursor changing to pointer).