### PR TITLE
[CCLCC] Movie disk can be activated by clicking on any place after exiting Movie fix.

### DIFF
--- a/src/games/cclcc/moviemenu.cpp
+++ b/src/games/cclcc/moviemenu.cpp
@@ -14,6 +14,7 @@ MovieMenu::MovieMenu() : LibrarySubmenu() {
     const auto& diskSprite = MovieDiskSprites[i];
     const auto& diskHighlightSprite = MovieDiskHighlightSprites[i];
     auto movieOnclick = [](Widgets::Button* target) {
+      target->Hovered = false;
       ScrWork[SW_MOVIEMODE_CUR] = MovieDiskPlayIds[target->Id];
       LibraryMenuPtr->AllowsScriptInput = true;
       Audio::PlayInGroup(Audio::ACG_SE, "sysse", 2, false, 0);


### PR DESCRIPTION
This PR will fix CCLCC bug where Movie disk can be activated by clicking on any place (without moving mouse) after exiting Movie.