### PR TITLE
[CCLCC] [CHLCC] Some changes to more match official PC ports.

### DIFF
--- a/src/games/cclcc/tipsmenu.cpp
+++ b/src/games/cclcc/tipsmenu.cpp
@@ -190,8 +190,10 @@ void TipsMenu::Update(float dt) {
   if (State != Hidden) {
     FadeAnimation.Update(dt);
     TransitionAnimation.Update(dt);
-    for (int i = 0; i < TabCount; i++) {
-      TipsTabs[i]->Update(dt);
+    if (State == Shown) {
+      for (int i = 0; i < TabCount; i++) {
+        TipsTabs[i]->Update(dt);
+      }
     }
   }
 

--- a/src/games/chlcc/musicmenu.cpp
+++ b/src/games/chlcc/musicmenu.cpp
@@ -393,17 +393,6 @@ void MusicMenu::UpdateInput(float dt) {
         ScrollY = 0;
       } else if (CurrentlyFocusedElement == MainItems->Children.back()) {
         ScrollY = MainScrollbar.EndValue;
-      } else {
-        float targetScroll = CurrentlyFocusedElement->Bounds.Y -
-                             MainItems->GetFirstFocusableChild()->Bounds.Y;
-        // if focused item is out of bounds, we scroll to it if focus has
-        // changed
-        if (targetScroll <= ScrollY) {
-          ScrollY = targetScroll;
-        } else {
-          ScrollY = targetScroll - SelectableItemsPerPage * TrackOffset.y;
-        }
-        MainScrollbar.ClampValue();
       }
     }
 
@@ -427,7 +416,6 @@ void MusicMenu::UpdateInput(float dt) {
       MainScrollbar.ClampValue();
     }
 
-    MainItems->UpdateInput(dt);
     MainScrollbar.UpdateInput(dt);
     PlayModeRepeatClickArea.UpdateInput(dt);
     PlayModeAllClickArea.UpdateInput(dt);
@@ -447,7 +435,18 @@ void MusicMenu::UpdateInput(float dt) {
         auto button = static_cast<Widgets::CHLCC::TrackSelectButton*>(child);
         button->MoveTracks(itemsPos);
       }
+
+      if (MainScrollbar.IsScrollHeld() && CurrentlyFocusedElement) {
+        // advance focus during drag
+        FocusDirection dir = (delta < 0) ? FDIR_DOWN : FDIR_UP;
+        int steps = static_cast<int>(std::abs(delta) / TrackOffset.y);
+        for (int i = 0; i < steps; i++) {
+          AdvanceFocus(dir);
+        }
+      }
     }
+
+    if (!MainScrollbar.IsScrollHeld()) MainItems->UpdateInput(dt);
 
     if (PADinputButtonWentDown & PAD1Y) {
       ++PlaybackMode;

--- a/src/games/chlcc/tipsmenu.cpp
+++ b/src/games/chlcc/tipsmenu.cpp
@@ -544,7 +544,6 @@ void TipsMenu::UpdatePageInput(float dt) {
   UI::TipsMenu::UpdateInput(dt);
 
   auto* curPage = static_cast<Group*>(*ItemsList.GetCurrent());
-  curPage->UpdateInput(dt);
 
   if (CurrentlyFocusedElement != prevEntry && checkScrollBounds()) {
     if (CurrentlyFocusedElement == curPage->GetFirstFocusableChild()) {
@@ -571,7 +570,21 @@ void TipsMenu::UpdatePageInput(float dt) {
       delta = newDelta;
     }
     curPage->Move({0, delta});
+
+    if (TipsEntriesScrollbar && TipsEntriesScrollbar->IsScrollHeld() &&
+        CurrentlyFocusedElement) {
+      // advance focus during drag
+      FocusDirection dir = (delta < 0) ? FDIR_DOWN : FDIR_UP;
+      Widget* startElement = CurrentlyFocusedElement;
+      while (!TipsListBounds.Contains(CurrentlyFocusedElement->Bounds)) {
+        AdvanceFocus(dir);
+        if (CurrentlyFocusedElement == startElement) break;
+      }
+    }
   }
+
+  if (!TipsEntriesScrollbar || !TipsEntriesScrollbar->IsScrollHeld())
+    curPage->UpdateInput(dt);
 }
 
 void TipsMenu::DrawTipsTree() {

--- a/src/ui/backlogmenu.cpp
+++ b/src/ui/backlogmenu.cpp
@@ -206,7 +206,6 @@ void BacklogMenu::UpdateScrollingInput(float dt) {
 
 void BacklogMenu::UpdateInput(float dt) {
   MainScrollbar->UpdateInput(dt);
-  MainItems->UpdateInput(dt);
   UpdatePageUpDownInput(dt);
   UpdateScrollingInput(dt);
 
@@ -248,6 +247,7 @@ void BacklogMenu::Update(float dt) {
     }
 
     MainItems->Update(dt);
+    if (!MainScrollbar->IsScrollHeld()) MainItems->UpdateInput(dt);
     MainScrollbar->Update(dt);
 
     // Handle entry moving out of hover bounds

--- a/src/ui/widgets/backlogentry.cpp
+++ b/src/ui/widgets/backlogentry.cpp
@@ -75,15 +75,13 @@ void BacklogEntry::UpdateInput(float dt) {
   if (Enabled) {
     RectF entryHoverBounds =
         RectF(HoverBounds.X, Bounds.Y, HoverBounds.Width, Bounds.Height);
-    if (Input::CurrentInputDevice == Input::Device::Mouse &&
-        Input::PrevMousePos != Input::CurMousePos) {
+    if (Input::CurrentInputDevice == Input::Device::Mouse) {
       Hovered =
           entryHoverBounds.ContainsPoint(Input::CurMousePos) &&
           HoverBounds.Y <= Bounds.Y &&
           (Bounds.Y + Bounds.Height) <= (HoverBounds.Y + HoverBounds.Height);
     } else if (Input::CurrentInputDevice == Input::Device::Touch &&
-               Input::TouchIsDown[0] &&
-               Input::PrevMousePos != Input::CurTouchPos) {
+               Input::TouchIsDown[0]) {
       Hovered =
           entryHoverBounds.ContainsPoint(Input::CurTouchPos) &&
           HoverBounds.Y <= Bounds.Y &&

--- a/src/ui/widgets/button.cpp
+++ b/src/ui/widgets/button.cpp
@@ -28,12 +28,10 @@ Button::Button(int id, Sprite const& norm, Sprite const& focused,
 void Button::UpdateInput(float dt) {
   if (Enabled) {
     const RectF& bounds = (HoverBounds != RectF{}) ? HoverBounds : Bounds;
-    if (Input::CurrentInputDevice == Input::Device::Mouse &&
-        Input::PrevMousePos != Input::CurMousePos) {
+    if (Input::CurrentInputDevice == Input::Device::Mouse) {
       Hovered = bounds.ContainsPoint(Input::CurMousePos);
     } else if (Input::CurrentInputDevice == Input::Device::Touch &&
-               Input::TouchIsDown[0] &&
-               Input::PrevTouchPos != Input::CurTouchPos) {
+               Input::TouchIsDown[0]) {
       Hovered = bounds.ContainsPoint(Input::CurTouchPos);
     }
     if (OnClickHandler && HasFocus &&


### PR DESCRIPTION
This PR will:

- Make in CCLCC and CHLCC Tips,Music,Backlog menu update hover when user scrolls with his mouse (like in CC and CHN official  PC ports).
- Disable hover update in CCLCC and CHLCC Tips,Music,Backlog menu when user drags scrollbar (like in CC and CHN official PC ports).
- Make hover up or down in CCLCC and CHLCC Tips menu and CHLCC Music menu when user drags scrollbar (like in CC and CHN official PC ports).
- Make tip in CCLCC Tips menu "hide" after one scroll (or scrollbar drag or by one input from keyboard/gamepad) (like in CC official port).