### PR TITLE
Tips Improvements + Minor fixes

### DIFF
--- a/profiles/chlcc/dialogue.lua
+++ b/profiles/chlcc/dialogue.lua
@@ -120,7 +120,7 @@ MakeAnimation({
     Name = "WaitIconSpriteAnimDef",
     Sheet = "Data",
     FirstFrameX = 0,
-    FirstFrameY = 96,
+    FirstFrameY = 97,
     FrameWidth = 34,
     ColWidth = 34,
     FrameHeight = 34,

--- a/src/games/chlcc/tipsmenu.h
+++ b/src/games/chlcc/tipsmenu.h
@@ -5,10 +5,10 @@
 #include "../../ui/tipsmenu.h"
 #include "../../ui/widgets/group.h"
 #include "../../ui/widgets/button.h"
+#include "../../ui/widgets/clickarea.h"
 #include "../../ui/widgets/carousel.h"
 #include "../../ui/widgets/label.h"
 #include "../../ui/widgets/scrollbar.h"
-#include "../../data/tipssystem.h"
 
 namespace Impacto {
 namespace UI {
@@ -31,7 +31,7 @@ class TipsMenu : public UI::TipsMenu {
 
  protected:
   void SwitchToTipId(int id) override;
-  void NextTipPage() override;
+  void AdvanceTipPage(TipAdvanceMode mode) override;
 
  private:
   void DrawCircles();
@@ -42,11 +42,12 @@ class TipsMenu : public UI::TipsMenu {
   void UpdateTitles();
   void HandlePageChange(Widget* cur, Widget* next);
 
+  Widgets::ClickArea PrevPageTipClickArea;
+  Widgets::ClickArea NextPageTipClickArea;
   Animation TitleFade;
   Animation FromSystemMenuTransition;
   SelectPromptAnimation SelectAnimation;
   MenuTransitionAnimation MenuTransition;
-
   glm::vec2 RedTitleLabelPos;
   glm::vec2 RightTitlePos;
   glm::vec2 LeftTitlePos;

--- a/src/games/chlcc/titlemenu.cpp
+++ b/src/games/chlcc/titlemenu.cpp
@@ -27,6 +27,8 @@ void TitleMenu::MenuButtonOnClick(Widgets::Button* target) {
   target->Hovered = false;
   ScrWork[SW_TITLECUR1] = target->Id;
   ChoiceMade = true;
+  // disable focus immediately, so MainItems couldn't get stuck being hovered
+  MainItems->HasFocus = false;
 }
 
 void TitleMenu::SecondaryButtonOnClick(Widgets::Button* target) {

--- a/src/games/mo6tw/tipsmenu.cpp
+++ b/src/games/mo6tw/tipsmenu.cpp
@@ -91,7 +91,7 @@ void TipsMenu::UpdateInput(float dt) {
     ItemsList.UpdateInput(dt);
     if (CurrentlyDisplayedTipId != -1) {
       if (PADinputButtonWentDown & PAD1X) {
-        NextTipPage();
+        AdvanceTipPage(TipAdvanceMode::NextLooped);
       }
     }
   }
@@ -279,11 +279,26 @@ void TipsMenu::SwitchToTipId(int id) {
   TextPage.AddString(&dummy);
 }
 
-void TipsMenu::NextTipPage() {
-  CurrentTipPage += 1;
+void TipsMenu::AdvanceTipPage(TipAdvanceMode mode) {
   auto currentRecord = TipsSystem::GetTipRecord(CurrentlyDisplayedTipId);
-  if (CurrentTipPage > currentRecord->NumberOfContentStrings)
-    CurrentTipPage = 1;
+  const int numberOfContentStrings =
+      static_cast<int>(currentRecord->NumberOfContentStrings);
+  if (numberOfContentStrings == 1) return;
+  CurrentTipPage += mode == TipAdvanceMode::PrevClamped ? -1 : 1;
+  switch (mode) {
+    case TipAdvanceMode::PrevClamped: {
+      CurrentTipPage = std::max(CurrentTipPage, 1);
+      break;
+    }
+    case TipAdvanceMode::NextClamped: {
+      CurrentTipPage = std::min(CurrentTipPage, numberOfContentStrings);
+      break;
+    }
+    case TipAdvanceMode::NextLooped: {
+      if (CurrentTipPage > numberOfContentStrings) CurrentTipPage = 1;
+      break;
+    }
+  }
 
   TextPage.Clear();
   Vm::Sc3VmThread dummy;

--- a/src/games/mo6tw/tipsmenu.h
+++ b/src/games/mo6tw/tipsmenu.h
@@ -5,7 +5,6 @@
 #include "../../ui/widgets/button.h"
 #include "../../ui/widgets/carousel.h"
 #include "../../ui/widgets/label.h"
-#include "../../data/tipssystem.h"
 
 namespace Impacto {
 namespace UI {
@@ -27,7 +26,7 @@ class TipsMenu : public UI::TipsMenu {
 
  protected:
   void SwitchToTipId(int id);
-  void NextTipPage();
+  void AdvanceTipPage(TipAdvanceMode mode);
 
  private:
   int CurrentTipPage = 1;

--- a/src/ui/tipsmenu.cpp
+++ b/src/ui/tipsmenu.cpp
@@ -9,7 +9,7 @@ void TipsMenu::Hide() {}
 void TipsMenu::Update(float dt) {}
 void TipsMenu::Render() {}
 void TipsMenu::SwitchToTipId(int id) {}
-void TipsMenu::NextTipPage() {}
+void TipsMenu::AdvanceTipPage(TipAdvanceMode mode) {}
 
 }  // namespace UI
 }  // namespace Impacto

--- a/src/ui/tipsmenu.h
+++ b/src/ui/tipsmenu.h
@@ -1,13 +1,14 @@
 #pragma once
 
 #include "menu.h"
-#include "../text/text.h"
 #include "../text/dialoguepage.h"
-#include "../ui/widgets/group.h"
 #include "../ui/widgets/label.h"
 
 namespace Impacto {
 namespace UI {
+
+// "Clamped" can't go outside [min,max], "Looped" loopes from last to first
+enum class TipAdvanceMode : uint8_t { PrevClamped, NextClamped, NextLooped };
 
 class TipsMenu : public Menu {
  public:
@@ -20,7 +21,7 @@ class TipsMenu : public Menu {
 
  protected:
   virtual void SwitchToTipId(int id);
-  virtual void NextTipPage();
+  virtual void AdvanceTipPage(TipAdvanceMode mode);
 
   int CurrentlyDisplayedTipId = -1;
 


### PR DESCRIPTION
- Fix scrollbar being updated when menu is hidden (causes wrong cursor on exiting tip)
- Change "NextTipPage" signature for more general pagination
- Add more ways to paginate multipage tips (scroll and clickArea)
- CHLCC Fix title menu hover lock after clicking main items
- CHLCC Fix waiting icon sprite offset