### PR TITLE
[CCLCC] Enable title menu entry highlight animation.

### DIFF
--- a/profiles/cclcc/hud/titlemenu.lua
+++ b/profiles/cclcc/hud/titlemenu.lua
@@ -62,8 +62,8 @@ root.TitleMenu = {
     MenuEntriesHighlightedSprites = {},
     MenuEntriesNum = 5,
     ChoiceBlinkAnimationDurationIn = 1,
-    HighlightAnimationDurationIn = 1/60,
-    HighlightAnimationDurationOut = 1/60,
+    HighlightAnimationDurationIn = 15/60,
+    HighlightAnimationDurationOut = 15/60,
     ExtraDisabledTint = 0x703030,
 };
 

--- a/src/ui/widgets/cclcc/titlebutton.cpp
+++ b/src/ui/widgets/cclcc/titlebutton.cpp
@@ -51,10 +51,20 @@ void TitleButton::Update(float dt) {
       Audio::PlayInGroup(Audio::ACG_SE, "sysse", 1, false, 0);
     }
     if (!IsSubButton) {
-      if (HighlightAnimation.IsOut() && HasFocus) {
-        HighlightAnimation.StartIn();
-      } else if (HighlightAnimation.IsIn() && !HasFocus) {
-        HighlightAnimation.StartOut();
+      if (HasFocus) {
+        if (Input::CurrentInputDevice == Input::Device::Mouse ||
+            Input::CurrentInputDevice == Input::Device::Touch) {
+          HighlightAnimation.Progress = 1.0f;
+        } else if (HighlightAnimation.IsOut()) {
+          HighlightAnimation.StartIn();
+        }
+      } else {
+        if (Input::CurrentInputDevice == Input::Device::Mouse ||
+            Input::CurrentInputDevice == Input::Device::Touch) {
+          HighlightAnimation.Progress = 0.0f;
+        } else if (HighlightAnimation.IsIn()) {
+          HighlightAnimation.StartOut();
+        }
       }
     }
   }


### PR DESCRIPTION
This PR will enable CCLCC title menu entry highlight animation (only for gamepad/keyboard). (Issue  #410 )

I think that disabling title menu entry highlight animation for mouse is the best solution, because animation was created for gamepad and there's not much that we can do, but I'm open to suggestions.