### PR TITLE
[CCLCC] Library menu doesn't open correctly if sub menu buttons were hovered before fade in fix.

### DIFF
--- a/src/games/cclcc/librarymenu.cpp
+++ b/src/games/cclcc/librarymenu.cpp
@@ -195,7 +195,9 @@ void LibraryMenu::Update(float dt) {
   ButtonBlinkAnimation.Update(dt);
   if (!moviePlaying && !cgViewerActive) {
     MainItems.Update(dt);
-    MainItems.UpdateInput(dt);
+    if (State == Shown) {
+      MainItems.UpdateInput(dt);
+    }
   }
 
   if (CurrentlyFocusedElement) {


### PR DESCRIPTION
This PR will fix Library menu doesn't open correctly if sub menu buttons were hovered before fade in (Issue #419)