### PR TITLE
[CCLCC] Sound additions/changes in Tips Menu.

### DIFF
--- a/src/games/cclcc/tipsmenu.cpp
+++ b/src/games/cclcc/tipsmenu.cpp
@@ -202,6 +202,9 @@ void TipsMenu::Update(float dt) {
     UpdateInput(dt);
     if (TipsScrollbar) {
       TipsScrollbar->UpdateInput(dt);
+      if ((PADinputMouseWentDown & PAD1A) && TipsScrollbar->IsScrollHeld()) {
+        Audio::PlayInGroup(Audio::ACG_SE, "sysse", 2, false, 0);
+      }
       TipsScrollbar->Update(dt);
       if (oldPageY != TipPageY) {
         TextPage.Move({0, oldPageY - TipPageY});
@@ -368,7 +371,11 @@ void TipsMenu::SwitchToTipId(int id) {
 void TipsMenu::SetActiveTab(TipsTabType type) {
   if (type == CurrentTabType || !TipsTabs[type]->GetTipEntriesCount()) return;
 
-  Audio::PlayInGroup(Audio::ACG_SE, "sysse", 1, false, 0);
+  if (PADinputMouseWentDown & PAD1A) {
+    Audio::PlayInGroup(Audio::ACG_SE, "sysse", 2, false, 0);
+  } else {
+    Audio::PlayInGroup(Audio::ACG_SE, "sysse", 1, false, 0);
+  }
 
   TipsTabs[CurrentTabType]->Hide();
   TipsTabs[type]->Show();

--- a/src/ui/widgets/cclcc/tipstabgroup.cpp
+++ b/src/ui/widgets/cclcc/tipstabgroup.cpp
@@ -5,6 +5,7 @@
 #include "../../../profile/ui/tipsmenu.h"
 #include "../../../profile/games/cclcc/tipsmenu.h"
 #include "../../../inputsystem.h"
+#include "../../../audio/audiosystem.h"
 #include "../../../vm/interface/input.h"
 #include "../../../ui/ui.h"
 #include "../../../text/text.h"
@@ -77,6 +78,10 @@ void TipsTabGroup::UpdatePageInput(float dt) {
   if (IsFocused) {
     auto prevEntry = CurrentlyFocusedElement;
     TipsEntriesScrollbar->UpdateInput(dt);
+    if ((PADinputMouseWentDown & PAD1A) &&
+        TipsEntriesScrollbar->IsScrollHeld()) {
+      Audio::PlayInGroup(Audio::ACG_SE, "sysse", 2, false, 0);
+    }
 
     auto checkScrollBounds = [&]() {
       return !TipsTabBounds.Contains(CurrentlyFocusedElement->Bounds);
@@ -213,6 +218,15 @@ void TipsTabGroup::Update(float dt) {
 
       if (!TipsEntriesScrollbar->IsScrollHeld())
         TipsEntriesGroup.UpdateInput(dt);
+
+      if (oldScrollPosY != ScrollPosY &&
+          Input::CurrentInputDevice == Input::Device::Mouse &&
+          (Input::MouseWheelDeltaY != 0 ||
+           TipsEntriesScrollbar->IsScrollHeld())) {
+        for (auto* entry : TipsEntryButtons) {
+          entry->PrevFocusState = entry->HasFocus;
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
This PR will:

- Disable selecting sound (sysse id 1) when user scrolling with his mouse or dragging scrollbar, but will still play when hovering tips with mouse or scrolling using keyboard/gamepad (like in C;C PC port).
- Add entering sound (sysse id 2) when clicking on scrollbar (In C;C PC port you couldn't hover scrollbar track, only thumb, so I dont know if it should play only when clicking on thumb or not).
- Add entering sound (sysse id 2) when changing Tips tabs with mouse click. Selecting sound (sysse id 1) will still play, when changing tabs with keyboard/gamepad (like in C;C PC port).