### PR TITLE
Exit button nullptr fixes

### DIFF
--- a/src/games/cclcc/titlemenu.cpp
+++ b/src/games/cclcc/titlemenu.cpp
@@ -144,11 +144,12 @@ TitleMenu::TitleMenu() {
 
   if (HasScriptedExitLogic) {
     // Exit menu button (Configuration/Patch driven)
-    Exit = new TitleButton(
+    auto* const exitPtr = new TitleButton(
         5, ExitSprite, ExitSprite, ItemHighlightSprite,
         glm::vec2(ItemHighlightOffsetX, (ItemYBase + (5 * ItemPadding))));
+    Exit.emplace(*exitPtr);
     setupBtn(
-        Exit,
+        exitPtr,
         [this](Widgets::Button* target) { return ExitButtonOnClick(target); },
         MainItems, FDIR_DOWN);
   }
@@ -697,7 +698,7 @@ void TitleMenu::ShowContinueItems() {
   Extra->Move(glm::vec2(0.0f, ItemPadding));
   Config->Move(glm::vec2(0.0f, ItemPadding));
   Help->Move(glm::vec2(0.0f, ItemPadding));
-  Exit->Move(glm::vec2(0.0f, ItemPadding));
+  if (Exit.has_value()) Exit->get().Move(glm::vec2(0.0f, ItemPadding));
   ContinueItems->Move(glm::vec2(Profile::DesignWidth / 2, 0.0f),
                       SecondaryFadeAnimation.DurationOut);
 }
@@ -711,7 +712,7 @@ void TitleMenu::HideContinueItems() {
   Extra->Move(glm::vec2(0.0f, -ItemPadding));
   Config->Move(glm::vec2(0.0f, -ItemPadding));
   Help->Move(glm::vec2(0.0f, -ItemPadding));
-  Exit->Move(glm::vec2(0.0f, -ItemPadding));
+  if (Exit.has_value()) Exit->get().Move(glm::vec2(0.0f, -ItemPadding));
 }
 
 void TitleMenu::ShowExtraItems() {
@@ -727,7 +728,7 @@ void TitleMenu::ShowExtraItems() {
 
   Config->Move(glm::vec2(0, ItemPadding));
   Help->Move(glm::vec2(0, ItemPadding));
-  Exit->Move(glm::vec2(0, ItemPadding));
+  if (Exit.has_value()) Exit->get().Move(glm::vec2(0, ItemPadding));
   ExtraItems->Move({Profile::DesignWidth / 2, 0.0f},
                    SecondaryFadeAnimation.DurationIn);
 }
@@ -741,7 +742,7 @@ void TitleMenu::HideExtraItems() {
   AllowsScriptInput = true;
   Config->Move(glm::vec2(0, -ItemPadding));
   Help->Move(glm::vec2(0, -ItemPadding));
-  Exit->Move(glm::vec2(0, -ItemPadding));
+  if (Exit.has_value()) Exit->get().Move(glm::vec2(0, -ItemPadding));
   Config->Enabled = true;
   Help->Enabled = true;
 }

--- a/src/games/cclcc/titlemenu.cpp
+++ b/src/games/cclcc/titlemenu.cpp
@@ -306,7 +306,12 @@ void TitleMenu::UpdateInput(float dt) {
     }
   }
   if (CurrentSubMenu && !CurrentSubMenu->HasFocus) return;
-  if (IsFocused) {
+
+  const bool buttonHighlightAnimationPlaying =
+      CurrentlyFocusedElement &&
+      static_cast<TitleButton*>(CurrentlyFocusedElement)
+          ->HighlightAnimation.IsPlaying();
+  if (IsFocused && !buttonHighlightAnimationPlaying) {
     Menu::UpdateInput(dt);
     if (MainItems->HasFocus && !CurrentSubMenu) {
       MainItems->UpdateInput(dt);

--- a/src/games/cclcc/titlemenu.h
+++ b/src/games/cclcc/titlemenu.h
@@ -44,7 +44,7 @@ class TitleMenu : public Menu {
   Widgets::CCLCC::TitleButton* Extra;
   Widgets::CCLCC::TitleButton* Config;
   Widgets::CCLCC::TitleButton* Help;
-  Widgets::CCLCC::TitleButton* Exit;
+  std::optional<std::reference_wrapper<Widgets::CCLCC::TitleButton>> Exit;
   Widgets::Label* MenuLabel;
 
   Widgets::Group* ContinueItems;

--- a/src/games/chlcc/titlemenu.cpp
+++ b/src/games/chlcc/titlemenu.cpp
@@ -91,12 +91,16 @@ TitleMenu::TitleMenu() {
 
   // Exit menu button (Configuration/Patch driven)
   if (HasScriptedExitLogic) {
-    Exit =
+    auto* const exitPtr =
         new TitleButton(4, ExitSprite, ExitHighlightSprite, ItemHighlightSprite,
                         glm::vec2(ItemHighlightOffset.x - 1.0f,
                                   ItemYBase - 1.0f + 4 * ItemPadding));
-    Exit->OnClickHandler = [this](auto* btn) { return ExitButtonOnClick(btn); };
-    MainItems->Add(Exit, FDIR_DOWN);
+    exitPtr->OnClickHandler = [this](auto* btn) {
+      return ExitButtonOnClick(btn);
+    };
+
+    Exit.emplace(*exitPtr);
+    MainItems->Add(exitPtr, FDIR_DOWN);
   }
 
   // Quick Load secondary Load menu button

--- a/src/games/chlcc/titlemenu.h
+++ b/src/games/chlcc/titlemenu.h
@@ -54,7 +54,7 @@ class TitleMenu : public Menu {
   Widgets::CHLCC::TitleButton* Load;
   Widgets::CHLCC::TitleButton* Extra;
   Widgets::CHLCC::TitleButton* System;
-  Widgets::CHLCC::TitleButton* Exit;
+  std::optional<std::reference_wrapper<Widgets::CHLCC::TitleButton>> Exit;
 
   Widgets::Group* LoadItems;
   Widgets::CHLCC::TitleButton* SubLoad;

--- a/src/ui/widget.cpp
+++ b/src/ui/widget.cpp
@@ -37,6 +37,7 @@ Widget* Widget::GetFocus(FocusDirection dir) {
   Widget* nextFocus = FocusElements[dir];
   while (nextFocus && !nextFocus->Enabled) {
     nextFocus = nextFocus->FocusElements[dir];
+    assert(nextFocus != this && "Entered an infinite loop");
   }
   return nextFocus;
 }


### PR DESCRIPTION
Fixes the title menu's Exit buttons throwing nullptr exceptions when `HasScriptedExitLogic` is false（ガッ！）

Also fixes an infinite loop in `Widget::GetFocus()` when advancing focus whilst the highlight animation is playing in the cclcc title menu, because _all_ buttons are disabled for this duration