### PR TITLE
Detect default audio device change on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -955,12 +955,14 @@ if (NOT DEFINED IMPACTO_DISABLE_OPENAL)
         src/audio/openal/audiobackend.cpp
         src/audio/openal/openalaudiochannel.cpp
         src/audio/openal/ffmpegaudioplayer.cpp
+	    src/audio/openal/notificationclient.cpp
     )
     list(APPEND Impacto_Header
         src/audio/openal/audiobackend.h
         src/audio/openal/openalaudiochannel.h
         src/audio/openal/audiocommon.h
         src/audio/openal/ffmpegaudioplayer.h
+	    src/audio/openal/notificationclient.h
     )
 
     list(APPEND Impacto_Include_Dirs ${OPENAL_INCLUDE_DIR})

--- a/src/audio/audiobackend.h
+++ b/src/audio/audiobackend.h
@@ -6,10 +6,14 @@ namespace Impacto {
 namespace Audio {
 
 class AudioBackend {
+ protected:
+  bool deviceChanged = false;
  public:
   virtual bool Init() { return true; };
 
   virtual void Shutdown() {};
+
+  virtual bool DeviceChanged() { return false; }
 };
 
 }  // namespace Audio

--- a/src/audio/audiochannel.h
+++ b/src/audio/audiochannel.h
@@ -26,6 +26,7 @@ class AudioChannel {
   virtual void Pause() = 0;
   virtual void Resume() = 0;
 
+  virtual void Reinit() = 0;
   virtual void Update(float dt) = 0;
   virtual float PositionInSeconds() const = 0;
 
@@ -80,6 +81,10 @@ class EmptyAudioChannel : public AudioChannel {
 
   void Resume() override {
     if (State == ACS_Paused) State = ACS_Playing;
+  }
+
+  void Reinit() override {
+
   }
 
   void Update(float dt) override {}

--- a/src/audio/audiosystem.cpp
+++ b/src/audio/audiosystem.cpp
@@ -190,6 +190,26 @@ void AudioInit() {
   IsInit = true;
 }
 
+void AudioReinit() {
+  Backend->Shutdown();
+  ImpLog(LogLevel::Info, LogChannel::Audio, "Reinitializing audio system\n");
+  if (!Backend->Init()) return;
+
+  for (int i = AC_SE0; i <= AC_SE2; i++)
+    Channels[i]->Reinit();
+  for (int i = AC_VOICE0; i <= AC_REV; i++)
+    Channels[i]->Reinit();
+  for (int i = AC_BGM0; i <= AC_BGM2; i++)
+    Channels[i]->Reinit();
+
+  Channels[AC_SSE0]->Reinit();
+  Channels[AC_SSE1]->Reinit();
+  Channels[AC_SSE2]->Reinit();
+  Channels[AC_SSE3]->Reinit();
+
+  IsInit = true;
+}
+
 void AudioSubtitlesStart(AudioChannel* channel) {
   using Profile::Subtitle::SubtitleMappings;
   std::optional<Subtitle::SubtitlePlayer> player;

--- a/src/audio/audiosystem.h
+++ b/src/audio/audiosystem.h
@@ -14,6 +14,7 @@ namespace Audio {
 void AudioInit();
 void AudioUpdate(float dt);
 void AudioShutdown();
+void AudioReinit();
 
 void AudioSubtitlesStart(AudioChannel* channel);
 void AudioSubtitlesUpdate();

--- a/src/audio/ffmpegaudioplayer.h
+++ b/src/audio/ffmpegaudioplayer.h
@@ -19,6 +19,7 @@ class FFmpegAudioPlayer {
   virtual void InitConvertContext(AVCodecContext* codecCtx) {};
   virtual void FillAudioBuffers() {};
   virtual void Process() {};
+  virtual void Reinit() {};
 
   virtual void Stop() {};
   virtual void Unload() {};

--- a/src/audio/openal/audiobackend.cpp
+++ b/src/audio/openal/audiobackend.cpp
@@ -1,5 +1,7 @@
 #include "audiobackend.h"
-
+#ifdef _WIN32
+#include "notificationclient.h"
+#endif
 #include "../../log.h"
 
 namespace Impacto {
@@ -8,8 +10,12 @@ namespace OpenAL {
 
 static ALCdevice* AlcDevice = 0;
 static ALCcontext* AlcContext = 0;
+#ifdef _WIN32
+static NotificationClient* NotifClient = 0;
+#endif
 
 bool AudioBackend::Init() {
+  deviceChanged = false;
   AlcDevice = alcOpenDevice(NULL);
   if (!AlcDevice) {
     ImpLog(LogLevel::Fatal, LogChannel::Audio,
@@ -27,6 +33,9 @@ bool AudioBackend::Init() {
     alcCloseDevice(AlcDevice);
     return false;
   }
+#ifdef _WIN32
+  if (!NotifClient) NotifClient = new NotificationClient(&deviceChanged);
+#endif
   return true;
 }
 
@@ -35,6 +44,7 @@ void AudioBackend::Shutdown() {
   if (AlcDevice) alcCloseDevice(AlcDevice);
 }
 
+bool AudioBackend::DeviceChanged() { return deviceChanged; }
 };  // namespace OpenAL
 };  // namespace Audio
 };  // namespace Impacto

--- a/src/audio/openal/audiobackend.h
+++ b/src/audio/openal/audiobackend.h
@@ -12,6 +12,8 @@ class AudioBackend : public Audio::AudioBackend {
   bool Init() override;
 
   void Shutdown() override;
+
+  bool DeviceChanged() override;
 };
 
 }  // namespace OpenAL

--- a/src/audio/openal/ffmpegaudioplayer.cpp
+++ b/src/audio/openal/ffmpegaudioplayer.cpp
@@ -37,6 +37,18 @@ void FFmpegAudioPlayer::Init() {
   alGenBuffers(AudioBufferCount, BufferIds);
 }
 
+void FFmpegAudioPlayer::Reinit() {
+  alGenSources(1, &ALSource);
+  alSourcef(ALSource, AL_PITCH, 1);
+  alSourcef(ALSource, AL_GAIN, 1);
+  alSource3f(ALSource, AL_POSITION, 0, 0, 0);
+  alSource3f(ALSource, AL_VELOCITY, 0, 0, 0);
+  alSourcei(ALSource, AL_LOOPING, AL_FALSE);
+
+  alGenBuffers(AudioBufferCount,BufferIds);
+  ReInit = true;
+}
+
 void FFmpegAudioPlayer::InitConvertContext(AVCodecContext* codecCtx) {
   AVChannelLayout stereoFormat;
   av_channel_layout_default(&stereoFormat, 2);
@@ -102,7 +114,7 @@ void FFmpegAudioPlayer::FillAudioBuffers() {
       totalSize += bufferSize;
     } while (totalSize <= 4096);
 
-    if (!First) {
+    if (!First && !ReInit) {
       alSourceUnqueueBuffers(ALSource, 1, &BufferIds[FirstFreeBuffer]);
     }
     FreeBufferCount--;
@@ -124,8 +136,9 @@ void FFmpegAudioPlayer::Process() {
 
   if (Player->AudioStream->FrameQueue.peek() != nullptr) {
     alGetSourcei(ALSource, AL_BUFFERS_PROCESSED, &FreeBufferCount);
-    if (First) {
+    if (First || ReInit) {
       FreeBufferCount = AudioBufferCount;
+      FirstFreeBuffer = 0;
     }
 
     int currentlyPlayingBuffer =
@@ -149,6 +162,7 @@ void FFmpegAudioPlayer::Process() {
       alSourcePlay(ALSource);
     }
     First = false;
+    ReInit = false;
   }
 }
 

--- a/src/audio/openal/ffmpegaudioplayer.h
+++ b/src/audio/openal/ffmpegaudioplayer.h
@@ -18,6 +18,7 @@ class FFmpegAudioPlayer : public Audio::FFmpegAudioPlayer {
   void InitConvertContext(AVCodecContext* codecCtx) override;
   void FillAudioBuffers() override;
   void Process() override;
+  void Reinit() override;
 
   void Stop() override;
   void Unload() override;
@@ -32,6 +33,7 @@ class FFmpegAudioPlayer : public Audio::FFmpegAudioPlayer {
   int FreeBufferCount = AudioBufferCount;
   int BufferStartPositions[AudioBufferCount] = {};
   bool First = true;
+  bool ReInit = false;
 };
 
 }  // namespace OpenAL

--- a/src/audio/openal/notificationclient.cpp
+++ b/src/audio/openal/notificationclient.cpp
@@ -1,0 +1,51 @@
+#ifdef _WIN32
+#include "notificationclient.h"
+namespace Impacto {
+namespace Audio {
+namespace OpenAL {
+bool NotificationClient::Start() {
+  // Initialize the COM library for the current thread
+  HRESULT ihr = CoInitialize(NULL);
+
+  if (SUCCEEDED(ihr)) {
+    // Create the device enumerator
+    IMMDeviceEnumerator* pEnumerator;
+    HRESULT hr =
+        CoCreateInstance(__uuidof(MMDeviceEnumerator), NULL, CLSCTX_ALL,
+                         __uuidof(IMMDeviceEnumerator), (void**)&pEnumerator);
+    if (SUCCEEDED(hr)) {
+      // Register for device change notifications
+      hr = pEnumerator->RegisterEndpointNotificationCallback(this);
+      m_pEnumerator = pEnumerator;
+
+      return true;
+    }
+
+    CoUninitialize();
+  }
+
+  return false;
+}
+
+ULONG STDMETHODCALLTYPE NotificationClient::Release() {
+  ULONG ulRef = InterlockedDecrement(&m_cRef);
+  if (0 == ulRef) {
+    delete this;
+  }
+  return ulRef;
+}
+
+void NotificationClient::Close() {
+  // Unregister the device enumerator
+  if (m_pEnumerator) {
+    m_pEnumerator->UnregisterEndpointNotificationCallback(this);
+    m_pEnumerator->Release();
+  }
+
+  // Uninitialize the COM library for the current thread
+  CoUninitialize();
+}
+};  // namespace OpenAL
+};  // namespace Audio
+};  // namespace Impacto
+#endif  // _WIN32

--- a/src/audio/openal/notificationclient.h
+++ b/src/audio/openal/notificationclient.h
@@ -1,0 +1,78 @@
+#pragma once
+#ifdef _WIN32
+#include <Windows.h>
+#include <mmdeviceapi.h>
+#include <endpointvolume.h>
+
+namespace Impacto {
+namespace Audio {
+namespace OpenAL {
+    //I took this from stackoverflow
+    //https://stackoverflow.com/questions/74965245/how-to-detect-default-audio-output-device-change-in-windows
+class NotificationClient : public IMMNotificationClient {
+ public:
+  NotificationClient(bool* deviceChanged) {
+    _deviceChanged = deviceChanged;
+    Start();
+  }
+
+  ~NotificationClient() { Close(); }
+
+  bool Start();
+
+  void Close();
+
+  // IUnknown methods
+  STDMETHOD(QueryInterface)(REFIID riid, void** ppvObject) {
+    if (riid == IID_IUnknown || riid == __uuidof(IMMNotificationClient)) {
+      *ppvObject = static_cast<IMMNotificationClient*>(this);
+      AddRef();
+      return S_OK;
+    }
+    return E_NOINTERFACE;
+  }
+
+  ULONG STDMETHODCALLTYPE AddRef() { return InterlockedIncrement(&m_cRef); }
+
+  ULONG STDMETHODCALLTYPE Release();
+
+  // IMMNotificationClient methods
+  STDMETHOD(OnDefaultDeviceChanged)(EDataFlow flow, ERole role,
+                                    LPCWSTR pwstrDeviceId) {
+    // Default audio device has been changed.
+    *_deviceChanged = true;
+    return S_OK;
+  }
+
+  STDMETHOD(OnDeviceAdded)(LPCWSTR pwstrDeviceId) {
+    // A new audio device has been added.
+    return S_OK;
+  }
+
+  STDMETHOD(OnDeviceRemoved)(LPCWSTR pwstrDeviceId) {
+    // An audio device has been removed.
+    return S_OK;
+  }
+
+  STDMETHOD(OnDeviceStateChanged)(LPCWSTR pwstrDeviceId, DWORD dwNewState) {
+    // The state of an audio device has changed.
+    return S_OK;
+  }
+
+  STDMETHOD(OnPropertyValueChanged)(LPCWSTR pwstrDeviceId,
+                                    const PROPERTYKEY key) {
+    // A property value of an audio device has changed.
+    return S_OK;
+  }
+
+ private:
+  bool* _deviceChanged;
+  LONG m_cRef;
+  IMMDeviceEnumerator* m_pEnumerator;
+};
+};  // namespace OpenAL
+};  // namespace Audio
+};  // namespace Impacto
+
+
+#endif

--- a/src/audio/openal/openalaudiochannel.cpp
+++ b/src/audio/openal/openalaudiochannel.cpp
@@ -35,6 +35,17 @@ OpenALAudioChannel::OpenALAudioChannel(AudioChannelId id,
   UpdateGain();
 }
 
+void OpenALAudioChannel::Reinit() {
+  alGenBuffers((ALsizei)AudioBuffers.size(), AudioBuffers.data());
+  alGenSources(1, &Source);
+
+  alSourcef(Source, AL_PITCH, 1);
+  alSource3f(Source, AL_POSITION, 0, 0, 0);
+  alSource3f(Source, AL_VELOCITY, 0, 0, 0);
+  alSourcei(Source, AL_LOOPING, AL_FALSE);
+  UpdateGain();
+}
+
 OpenALAudioChannel::~OpenALAudioChannel() {
   alDeleteSources(1, &Source);
   alDeleteBuffers((ALsizei)AudioBuffers.size(), AudioBuffers.data());

--- a/src/audio/openal/openalaudiochannel.h
+++ b/src/audio/openal/openalaudiochannel.h
@@ -18,6 +18,7 @@ class OpenALAudioChannel : public Audio::AudioChannel {
   void Pause() override;
   void Resume() override;
 
+  void Reinit() override;
   void Update(float dt) override;
 
   float PositionInSeconds() const override;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -311,6 +311,13 @@ void UpdateSystem(float dt) {
 }
 
 void Update(float dt) {
+#ifdef _WIN32
+  bool AudiDeviceChanged = false;
+  if (Audio::Backend) AudiDeviceChanged = Audio::Backend->DeviceChanged();
+  #else
+  const bool AudiDeviceChanged = false;
+#endif
+
   UpdateSystem(dt);
 
 #ifndef IMPACTO_DISABLE_IMGUI
@@ -326,10 +333,12 @@ void Update(float dt) {
   }
 
   if (+Profile::GameFeatures & +GameFeature::Audio) {
+    if (AudiDeviceChanged) Audio::AudioReinit();
     Audio::AudioUpdate(dt);
   }
 
   if (+Profile::GameFeatures & +GameFeature::Video) {
+    if (AudiDeviceChanged) Video::VideoReinit();
     Video::VideoUpdate(dt);
   }
 

--- a/src/video/ffmpegplayer.cpp
+++ b/src/video/ffmpegplayer.cpp
@@ -102,6 +102,8 @@ void FFmpegPlayer::Init() {
   IsInit = true;
 }
 
+void FFmpegPlayer::Reinit() { AudioPlayer->Reinit(); }
+
 AVBufferRef* FFmpegPlayer::HwDecoderInit(const AVCodec* codec) {
   for (int i = 0;; i++) {
     const AVCodecHWConfig* cfg = avcodec_get_hw_config(codec, i);

--- a/src/video/ffmpegplayer.h
+++ b/src/video/ffmpegplayer.h
@@ -42,6 +42,7 @@ class FFmpegPlayer : public VideoPlayer {
   void Play(Io::Stream* stream, bool loop, bool alpha) override;
   void Stop() override;
   void Seek(int64_t pos) override;
+  void Reinit() override;
 
   void Update(float dt) override;
   void Render(float videoAlpha) override;

--- a/src/video/videoplayer.h
+++ b/src/video/videoplayer.h
@@ -17,6 +17,7 @@ class VideoPlayer {
   virtual void Stop() {};
   virtual void Seek(int64_t pos) {};
 
+  virtual void Reinit() {};
   virtual void Update(float dt) {};
   virtual void Render(float videoAlpha) {};
 

--- a/src/video/videosystem.cpp
+++ b/src/video/videosystem.cpp
@@ -50,5 +50,11 @@ void VideoRender(float videoAlpha) {
   }
 }
 
+void VideoReinit() {
+  for (int i = 0; i < VP_Count; i++) {
+    Players[i]->Reinit();
+  }
+}
+
 }  // namespace Video
 }  // namespace Impacto

--- a/src/video/videosystem.h
+++ b/src/video/videosystem.h
@@ -14,6 +14,7 @@ void VideoInit();
 void VideoUpdate(float dt);
 void VideoRender(float videoAlpha);
 void VideoShutdown();
+void VideoReinit();
 
 }  // namespace Video
 }  // namespace Impacto


### PR DESCRIPTION
Use IMMNotificationClient interface from win32api to get notified of the change and reintialize openal

I tested it on windows 10/11 worked in both cases

If anything is wrong I'll try to fix it