### PR TITLE
Make the delusion trigger animation skippable

### DIFF
--- a/src/games/chlcc/delusiontrigger.cpp
+++ b/src/games/chlcc/delusiontrigger.cpp
@@ -79,6 +79,11 @@ void DelusionTrigger::UpdateHiding(float dt) {
     State = Hidden;
     Reset();
   };
+  if (GetFlag(SF_MESSKIP)) {
+    SetFlag(SF_DELUSION_UI_ANIM_WAIT, 0);
+    Reset();
+    return;
+  }
   if (AnimationState < 13) {
     AnimCounter++;
     switch (AnimationState) {
@@ -153,6 +158,10 @@ void DelusionTrigger::UpdateHiding(float dt) {
 }
 
 void DelusionTrigger::UpdateShowing(float dt) {
+  if (GetFlag(SF_MESSKIP)) {
+    Load();
+    return;
+  }
   switch (AnimationState) {
     case 0: {
       SpinRate -= 24;
@@ -539,7 +548,7 @@ void DelusionTrigger::Load() {
   UnderlayerXOffset = 20000;
   AnimCounter = 0;
   SpinAngle = 0;
-  SpinRate = 5;
+  SpinRate = -5;
   BackgroundAlpha = 256;
   TextSystem.Clear();
   switch (DelusionState) {

--- a/src/games/chlcc/delusiontrigger.cpp
+++ b/src/games/chlcc/delusiontrigger.cpp
@@ -72,13 +72,6 @@ void DelusionTrigger::Hide() {
 }
 
 void DelusionTrigger::UpdateHiding(float dt) {
-  auto setHidden = [this] {
-    AnimCounter = 0;
-    AnimationState = 0;
-    SetFlag(SF_DELUSION_UI_ANIM_WAIT, 0);
-    State = Hidden;
-    Reset();
-  };
   if (AnimationState < 13) {
     AnimCounter++;
     switch (AnimationState) {
@@ -125,7 +118,7 @@ void DelusionTrigger::UpdateHiding(float dt) {
           BackgroundAlpha -= 16;
         }
         if (AnimCounter == 50) {
-          setHidden();
+          Reset();
         }
       } break;
       case 11: {
@@ -135,7 +128,7 @@ void DelusionTrigger::UpdateHiding(float dt) {
           BackgroundAlpha -= 8;
         }
         if (AnimCounter == 100) {
-          setHidden();
+          Reset();
         }
       } break;
       case 12: {
@@ -145,7 +138,7 @@ void DelusionTrigger::UpdateHiding(float dt) {
           BackgroundAlpha -= 8;
         }
         if (AnimCounter == 100) {
-          setHidden();
+          Reset();
         }
       } break;
     }
@@ -532,6 +525,7 @@ void DelusionTrigger::Render() {
 }
 
 void DelusionTrigger::Load() {
+  SetFlag(SF_DELUSION_UI_ANIM_WAIT, 0);
   State = Shown;
   ShakeState = 0;
   MaskOffsetX = 0;
@@ -576,6 +570,7 @@ void DelusionTrigger::Load() {
 }
 
 void DelusionTrigger::Reset() {
+  SetFlag(SF_DELUSION_UI_ANIM_WAIT, 0);
   State = Hidden;
   SpinAngle = 62431;
   SpinRate = 0;
@@ -593,21 +588,6 @@ void DelusionTrigger::Reset() {
   LeftHeartFade.Finish(AnimationDirection::In);
   RightHeartFade.Finish(AnimationDirection::In);
   TextSystem.Clear();
-}
-
-void DelusionTrigger::SetHidden() {
-  if (GetFlag(SF_MESALLSKIP) && State == Hiding) {
-    Reset();
-    SetFlag(SF_DELUSION_UI_ANIM_WAIT, 0);
-  }
-}
-
-void DelusionTrigger::SetShown() {
-  if ((SkipModeEnabled ||
-       GetControlState(CT_ForceSkip, InputDownType::IsDown)) &&
-      GetFlag(SF_MESALLSKIP) && State == Showing) {
-    Load();
-  }
 }
 
 DelusionTextSystem::DelusionTextSystem() {

--- a/src/games/chlcc/delusiontrigger.cpp
+++ b/src/games/chlcc/delusiontrigger.cpp
@@ -45,8 +45,8 @@ void DelusionTrigger::Show() {
     State = Showing;
     DelusionState = DS_Neutral;
     MaskScaleFactor = 131072;
-    SpinAngle = 0;
-    SpinRate = 3072;
+    SpinAngle = 62431;
+    SpinRate = -3072;
     UnderlayerAlpha = 0;
     BackgroundAlpha = 0;
     AnimationState = 0;
@@ -80,8 +80,15 @@ void DelusionTrigger::UpdateHiding(float dt) {
     Reset();
   };
   if (GetFlag(SF_MESSKIP)) {
-    SetFlag(SF_DELUSION_UI_ANIM_WAIT, 0);
-    Reset();
+    if (AnimCounter > 50) {
+      SetFlag(SF_DELUSION_UI_ANIM_WAIT, 0);
+      Reset();
+    } else {
+      BackgroundAlpha = 0;
+      MaskScaleFactor = 193536;
+      AnimCounter++;
+    }
+
     return;
   }
   if (AnimationState < 13) {
@@ -134,7 +141,7 @@ void DelusionTrigger::UpdateHiding(float dt) {
         }
       } break;
       case 11: {
-        SpinRate += 24;
+        SpinRate -= 24;
         MaskScaleFactor += 1536;
         if (AnimCounter > 67) {
           BackgroundAlpha -= 8;
@@ -144,7 +151,7 @@ void DelusionTrigger::UpdateHiding(float dt) {
         }
       } break;
       case 12: {
-        SpinRate -= 24;
+        SpinRate += 24;
         MaskScaleFactor += 1536;
         if (AnimCounter > 67) {
           BackgroundAlpha -= 8;
@@ -164,7 +171,7 @@ void DelusionTrigger::UpdateShowing(float dt) {
   }
   switch (AnimationState) {
     case 0: {
-      SpinRate -= 24;
+      SpinRate += 24;
       MaskScaleFactor -= 736;
 
       if (UnderlayerAlpha < 256) {
@@ -176,7 +183,7 @@ void DelusionTrigger::UpdateShowing(float dt) {
 
       if (SpinRate == 0) {
         AnimationState += 1;
-        SpinRate = -1024;
+        SpinRate = 1024;
       }
     } break;
     case 1:
@@ -194,7 +201,7 @@ void DelusionTrigger::UpdateShowing(float dt) {
       if (AnimCounter == 15) {
         AnimationState += 1;
         AnimCounter = 0;
-        SpinRate = 1024;
+        SpinRate = -1024;
       }
     } break;
     case 4: {
@@ -202,7 +209,7 @@ void DelusionTrigger::UpdateShowing(float dt) {
       if (AnimCounter == 15) {
         AnimationState += 1;
         AnimCounter = 0;
-        SpinRate = -1024;
+        SpinRate = 1024;
       }
     } break;
     case 6: {
@@ -210,7 +217,7 @@ void DelusionTrigger::UpdateShowing(float dt) {
       if (AnimCounter == 20) {
         AnimationState += 1;
         AnimCounter = 0;
-        SpinRate = 5;
+        SpinRate = -5;
       }
     } break;
     case 7: {
@@ -224,8 +231,8 @@ void DelusionTrigger::UpdateShowing(float dt) {
     case 8: {
       MaskScaleFactor += 3072;
       if (MaskScaleFactor > 79999) {
-        AnimationState = 0;
-        AnimCounter = 0;
+        AnimationState = -1;
+        AnimCounter = -1;
         SetFlag(SF_DELUSION_UI_ANIM_WAIT, 0);
       }
     } break;
@@ -334,7 +341,8 @@ void DelusionTrigger::UpdateShown(float dt) {
              TextSystem.DelusionTextFade.IsStopped()) {
     TriggerRight();
   }
-
+  AnimationState = 0;
+  AnimCounter = 0;
   const AnimationDirection leftHeartDirection =
       (ScrWork[SW_DELUSION_STATE] == DS_Positive) ? AnimationDirection::Out
                                                   : AnimationDirection::In;
@@ -547,7 +555,7 @@ void DelusionTrigger::Load() {
 
   UnderlayerXOffset = 20000;
   AnimCounter = 0;
-  SpinAngle = 0;
+  SpinAngle = 62431;
   SpinRate = -5;
   BackgroundAlpha = 256;
   TextSystem.Clear();
@@ -585,7 +593,7 @@ void DelusionTrigger::Load() {
 
 void DelusionTrigger::Reset() {
   State = Hidden;
-  SpinAngle = 0;
+  SpinAngle = 62431;
   SpinRate = 0;
   UnderlayerAlpha = 0;
   UnderlayerXOffset = 0;

--- a/src/games/chlcc/delusiontrigger.cpp
+++ b/src/games/chlcc/delusiontrigger.cpp
@@ -353,8 +353,8 @@ void DelusionTrigger::UpdateShown(float dt) {
     }
     if (ScrWork[SW_DELUSION_STATE] == DS_Positive) {
       TriggerOnTint = RgbIntToFloat(0xffb0ce);
-      if (SpinRate < 40) {
-        SpinRate = SpinRate + 2;
+      if (SpinRate > -40) {
+        SpinRate = SpinRate - 2;
         anim = true;
       }
       if (UnderlayerXRate < 2400) {
@@ -370,8 +370,8 @@ void DelusionTrigger::UpdateShown(float dt) {
       TriggerOnTint = ScrWork[SW_DELUSION_NEG_TXT_IDX]
                           ? RgbIntToFloat(0xffb0ce)
                           : RgbIntToFloat(0x2242e3);
-      if (SpinRate > -40) {
-        SpinRate = SpinRate - 2;
+      if (SpinRate < 40) {
+        SpinRate = SpinRate + 2;
         anim = true;
       }
       if (UnderlayerXRate > -2400) {

--- a/src/games/chlcc/delusiontrigger.cpp
+++ b/src/games/chlcc/delusiontrigger.cpp
@@ -79,18 +79,6 @@ void DelusionTrigger::UpdateHiding(float dt) {
     State = Hidden;
     Reset();
   };
-  if (GetFlag(SF_MESSKIP)) {
-    if (AnimCounter > 50) {
-      SetFlag(SF_DELUSION_UI_ANIM_WAIT, 0);
-      Reset();
-    } else {
-      BackgroundAlpha = 0;
-      MaskScaleFactor = 193536;
-      AnimCounter++;
-    }
-
-    return;
-  }
   if (AnimationState < 13) {
     AnimCounter++;
     switch (AnimationState) {
@@ -165,10 +153,6 @@ void DelusionTrigger::UpdateHiding(float dt) {
 }
 
 void DelusionTrigger::UpdateShowing(float dt) {
-  if (GetFlag(SF_MESSKIP)) {
-    Load();
-    return;
-  }
   switch (AnimationState) {
     case 0: {
       SpinRate += 24;
@@ -609,6 +593,21 @@ void DelusionTrigger::Reset() {
   LeftHeartFade.Finish(AnimationDirection::In);
   RightHeartFade.Finish(AnimationDirection::In);
   TextSystem.Clear();
+}
+
+void DelusionTrigger::SetHidden() {
+  if (GetFlag(SF_MESALLSKIP) && State == Hiding) {
+    Reset();
+    SetFlag(SF_DELUSION_UI_ANIM_WAIT, 0);
+  }
+}
+
+void DelusionTrigger::SetShown() {
+  if ((SkipModeEnabled ||
+       GetControlState(CT_ForceSkip, InputDownType::IsDown)) &&
+      GetFlag(SF_MESALLSKIP) && State == Showing) {
+    Load();
+  }
 }
 
 DelusionTextSystem::DelusionTextSystem() {

--- a/src/games/chlcc/delusiontrigger.h
+++ b/src/games/chlcc/delusiontrigger.h
@@ -44,6 +44,8 @@ class DelusionTrigger {
   void Render();
   void Load();
   void Reset();
+  void SetHidden();
+  void SetShown();
 
   static DelusionTrigger& GetInstance() {
     static DelusionTrigger impl;

--- a/src/games/chlcc/delusiontrigger.h
+++ b/src/games/chlcc/delusiontrigger.h
@@ -44,8 +44,6 @@ class DelusionTrigger {
   void Render();
   void Load();
   void Reset();
-  void SetHidden();
-  void SetShown();
 
   static DelusionTrigger& GetInstance() {
     static DelusionTrigger impl;

--- a/src/vm/inst_gamespecific.cpp
+++ b/src/vm/inst_gamespecific.cpp
@@ -1036,8 +1036,12 @@ VmInstruction(InstDelusionTriggerCHLCC) {
       inst.State = UI::Shown;
       break;
     case 2:
+      inst.SetShown();
+      BlockThread;
+      break;
     case 7:
       // handled by update
+      inst.SetHidden();
       BlockThread;
       break;
     case 0:

--- a/src/vm/inst_gamespecific.cpp
+++ b/src/vm/inst_gamespecific.cpp
@@ -1023,6 +1023,7 @@ VmInstruction(InstDelusionTriggerCHLCC) {
     case 1: {
       // start show
       inst.Show();
+      BlockThread;
     } break;
     case 5: {
       // restore delusion from load save
@@ -1036,12 +1037,12 @@ VmInstruction(InstDelusionTriggerCHLCC) {
       inst.State = UI::Shown;
       break;
     case 2:
-      inst.SetShown();
+      if (GetFlag(SF_MESALLSKIP)) inst.Load();
       BlockThread;
       break;
     case 7:
       // handled by update
-      inst.SetHidden();
+      if (GetFlag(SF_MESALLSKIP)) inst.Reset();
       BlockThread;
       break;
     case 0:


### PR DESCRIPTION
Make the delusion trigger animation skippable in C;H LCC #484 

On a side note I noticed that the triggers in impacto make it spin the opposite way compared to the PS3 and switch version is this deliberate?