### PR TITLE
Allow sprite sheets to be loaded by the script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ set(Impacto_Src
     src/mem.cpp
     src/modelviewer.cpp
     src/characterviewer.cpp
+    src/spritesheet.cpp
     src/spriteanimation.cpp
     src/sequencedanimation.cpp
     src/background2d.cpp

--- a/src/io/assetpath.h
+++ b/src/io/assetpath.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "stream.h"
+#include "../util.h"
 
 namespace Impacto {
 namespace Io {
@@ -13,6 +14,62 @@ class AssetPath {
 
   IoError Open(Stream** outStream);
   IoError Slurp(void*& outMemory, int64_t& outSize);
+};
+
+// structs below only used for SpriteSheets from System archive
+struct AssetPathKey {
+  uint32_t MountId;
+  uint32_t Id;
+
+  static AssetPath KeyToAssetPath(AssetPathKey const& val) {
+    std::string mount = "";
+    if (val.MountId == 2) {
+      mount = "system";
+    }
+    return AssetPath{.Mount = mount, .Id = val.Id};
+  }
+};
+
+struct AssetPathHash {
+  using is_transparent = void;
+
+  static uint32_t MountToId(std::string_view mount) {
+    if (mount == "system") return 2;
+    assert(false);
+    return 0;
+  }
+
+  static uint64_t Compute(uint32_t mountId, uint32_t id) {
+    uint64_t h1 = ankerl::unordered_dense::hash<uint32_t>{}(mountId);
+    uint64_t h2 = ankerl::unordered_dense::hash<uint32_t>{}(id);
+    std::size_t seed = 0;
+    HashCombine(seed, h1, h2);
+    return static_cast<uint64_t>(seed);
+  }
+
+  uint64_t operator()(const AssetPath& p) const {
+    return Compute(MountToId(p.Mount), p.Id);
+  }
+
+  uint64_t operator()(const AssetPathKey& k) const {
+    return Compute(k.MountId, k.Id);
+  }
+};
+
+struct AssetPathEqual {
+  using is_transparent = void;
+
+  bool operator()(const AssetPath& a, const AssetPath& b) const {
+    return a.Mount == b.Mount && a.Id == b.Id;
+  }
+
+  bool operator()(const AssetPath& a, const AssetPathKey& b) const {
+    return AssetPathHash::MountToId(a.Mount) == b.MountId && a.Id == b.Id;
+  }
+
+  bool operator()(const AssetPathKey& a, const AssetPath& b) const {
+    return (*this)(b, a);
+  }
 };
 
 }  // namespace Io

--- a/src/profile/animations.cpp
+++ b/src/profile/animations.cpp
@@ -19,7 +19,7 @@ void LoadAnimations() {
       EnsurePushMemberOfType("Frames", LUA_TTABLE);
 
       animation.FrameCount = (uint32_t)lua_rawlen(LuaState, -1);
-      animation.Frames = (Sprite*)malloc(animation.FrameCount * sizeof(Sprite));
+      animation.Frames = new Sprite[animation.FrameCount];
       PushInitialIndex();
       while (PushNextTableElement() != 0) {
         animation.Frames[EnsureGetKey<int32_t>() - 1] =

--- a/src/profile/sprites.cpp
+++ b/src/profile/sprites.cpp
@@ -35,20 +35,23 @@ void LoadSpritesheets() {
     SpriteSheet& sheet = SpriteSheets[name];
     sheet.DesignWidth = EnsureGetMember<float>("DesignWidth");
     sheet.DesignHeight = EnsureGetMember<float>("DesignHeight");
+    sheet.ScriptHandled = TryGetMember<bool>("ScriptHandled") == true;
+    sheet.Path = EnsureGetMember<Io::AssetPath>("Path");
 
-    Io::AssetPath asset = EnsureGetMember<Io::AssetPath>("Path");
+    if (sheet.ScriptHandled) {
+      sheet.Texture = Renderer->MapSpriteSheet(sheet);
+    } else {
+      Io::Stream* stream;
+      IoError err = sheet.Path.Open(&stream);
+      if (err != IoError_OK) {
+        ImpLog(LogLevel::Fatal, LogChannel::Profile,
+               "Could not open spritesheet {:s}\n", name);
+        Window->Shutdown();
+      }
 
-    Io::Stream* stream;
-    IoError err = asset.Open(&stream);
-    if (err != IoError_OK) {
-      ImpLog(LogLevel::Fatal, LogChannel::Profile,
-             "Could not open spritesheet {:s}\n", name);
-      Window->Shutdown();
+      futures.emplace_back(std::tuple(
+          name, std::async(std::launch::async, LoadTexture, stream, name)));
     }
-
-    futures.emplace_back(std::tuple(
-        name, std::async(std::launch::async, LoadTexture, stream, name)));
-
     Pop();
   }
 

--- a/src/renderer/dx9/renderer.h
+++ b/src/renderer/dx9/renderer.h
@@ -24,6 +24,11 @@ class Renderer : public BaseRenderer {
   void BeginFrame2D() override;
   void EndFrame() override;
 
+  uint32_t MapSpriteSheet(SpriteSheet const& sheet) override { return 0; };
+  bool LoadSurf(int surfId, int archiveId, int fileId) override {
+    return false;
+  };
+  void UnloadSurf(int surfId) override {};
   uint32_t SubmitTexture(TexFmt format, uint8_t* buffer, int width,
                          int height) override;
 

--- a/src/renderer/opengl/renderer.cpp
+++ b/src/renderer/opengl/renderer.cpp
@@ -9,6 +9,7 @@
 #include "3d/scene.h"
 #include "yuvframe.h"
 #include "nv12frame.h"
+#include <ankerl/unordered_dense.h>
 
 #ifndef IMPACTO_DISABLE_IMGUI
 #include <imgui_custom/backends/imgui_impl_opengl3.h>
@@ -176,6 +177,67 @@ void Renderer::EndFrame() {
   Drawing = false;
 
   glBindSampler(0, 0);
+}
+
+uint32_t Renderer::MapSpriteSheet(SpriteSheet const& sheet) {
+  if (!sheet.ScriptHandled) {
+    assert(false);
+    return 0;
+  }
+  auto currentId = static_cast<uint32_t>(SheetPathToId.size());
+  SheetPathToId.emplace(sheet.Path, currentId);
+
+  return currentId;
+}
+
+bool Renderer::LoadSurf(int surfId, int archiveId, int fileId) {
+  auto path = Io::AssetPathKey{.MountId = static_cast<uint32_t>(archiveId),
+                               .Id = static_cast<uint32_t>(fileId)};
+  auto lookupTextureIdIter = SheetPathToId.find(path);
+  if (lookupTextureIdIter == SheetPathToId.end()) {
+    return false;
+  }
+  SurfToId.try_emplace(surfId, path);
+
+  auto lookupTextureId = lookupTextureIdIter->second;
+
+  Io::AssetPath pathRes = Io::AssetPathKey::KeyToAssetPath(path);
+  Io::Stream* stream;
+  IoError err = pathRes.Open(&stream);
+  if (err != IoError_OK) {
+    ImpLog(LogLevel::Fatal, LogChannel::Profile,
+           "Could not open spritesheet\n");
+    Window->Shutdown();
+  }
+
+  Texture tex{};
+  tex.Load(stream);
+  uint32_t textureId = tex.Submit();
+  delete stream;
+
+  LookupTextureIdToTexture.try_emplace(lookupTextureId, textureId);
+  return true;
+}
+
+void Renderer::UnloadSurf(int surfId) {
+  auto surfToIdIter = SurfToId.find(surfId);
+  if (surfToIdIter == SurfToId.end()) {
+    return;
+  }
+  auto idFromSurf = surfToIdIter->second;
+  auto IdFromSheetIter = SheetPathToId.find(idFromSurf);
+  if (IdFromSheetIter == SheetPathToId.end()) {
+    assert(false);
+    return;
+  }
+  auto textureId = LookupTextureIdToTexture.find(IdFromSheetIter->second);
+  if (textureId == LookupTextureIdToTexture.end()) {
+    assert(false);
+    return;
+  }
+  FreeTexture(textureId->second);
+  LookupTextureIdToTexture.erase(IdFromSheetIter->second);
+  SurfToId.erase(surfId);
 }
 
 uint32_t Renderer::SubmitTexture(TexFmt format, uint8_t* buffer, int width,
@@ -398,9 +460,10 @@ void Renderer::DrawSprite(const Sprite& sprite, const CornersQuad& dest,
 
     UseShader(*SpriteShaderProgram, uniforms);
   }
+  auto texture = UnwrapTextureId(sprite);
 
-  UseTextures(std::array<std::pair<uint32_t, size_t>, 1>{
-      std::pair{sprite.Sheet.Texture, 0}});
+  UseTextures(
+      std::array<std::pair<uint32_t, size_t>, 1>{std::pair{texture, 0}});
 
   // OK, all good, make quad
 
@@ -455,10 +518,12 @@ void Renderer::DrawMaskedSprite(const Sprite& sprite, const Sprite& mask,
   };
 
   UseShader(*MaskedSpriteShaderProgram, uniforms);
+  auto texture = UnwrapTextureId(sprite);
+  auto maskTexture = UnwrapTextureId(mask);
 
   UseTextures(std::array<std::pair<uint32_t, size_t>, 2>{
-      std::pair{sprite.Sheet.Texture, 0},
-      std::pair{mask.Sheet.Texture, 2},
+      std::pair{texture, 0},
+      std::pair{maskTexture, 2},
   });
 
   // OK, all good, make quad
@@ -495,10 +560,12 @@ void Renderer::DrawMaskedBinarySprite(
   };
 
   UseShader(*MaskedSpriteBinaryShaderProgram, uniforms);
+  auto texture = UnwrapTextureId(sprite);
+  auto maskTexture = UnwrapTextureId(mask);
 
   UseTextures(std::array<std::pair<uint32_t, size_t>, 2>{
-      std::pair{sprite.Sheet.Texture, 0},
-      std::pair{mask.Sheet.Texture, 2},
+      std::pair{texture, 0},
+      std::pair{maskTexture, 2},
   });
 
   // OK, all good, make quad
@@ -556,10 +623,12 @@ void Renderer::DrawMaskedSpriteOverlay(
 
     UseShader(*MaskedSpriteNoAlphaShaderProgram, uniforms);
   }
+  auto texture = UnwrapTextureId(sprite);
+  auto maskTexture = UnwrapTextureId(mask);
 
   UseTextures(std::array<std::pair<uint32_t, size_t>, 2>{
-      std::pair{sprite.Sheet.Texture, 0},
-      std::pair{mask.Sheet.Texture, 2},
+      std::pair{texture, 0},
+      std::pair{maskTexture, 2},
   });
 
   // OK, all good, make quad
@@ -776,13 +845,17 @@ void Renderer::DrawPrimitives(
   }
 
   if (mask == nullptr) {
-    UseTextures(std::array<std::pair<uint32_t, size_t>, 1>{
-        std::pair{sheet.Texture, 0},
-    });
+    auto texture = UnwrapTextureId(sheet);
+
+    UseTextures(
+        std::array<std::pair<uint32_t, size_t>, 1>{std::pair{texture, 0}});
   } else {
+    auto texture = UnwrapTextureId(sheet);
+    auto maskTexture = UnwrapTextureId(*mask);
+
     UseTextures(std::array<std::pair<uint32_t, size_t>, 2>{
-        std::pair{sheet.Texture, 0},
-        std::pair{mask->Texture, 2},
+        std::pair{texture, 0},
+        std::pair{maskTexture, 2},
     });
   }
 
@@ -838,9 +911,12 @@ void Renderer::DrawCCMessageBox(Sprite const& sprite, Sprite const& mask,
 
   UseShader(*CCMessageBoxShaderProgram, uniforms);
 
+  auto texture = UnwrapTextureId(sprite);
+  auto maskTexture = UnwrapTextureId(mask);
+
   UseTextures(std::array<std::pair<uint32_t, size_t>, 2>{
-      std::pair{sprite.Sheet.Texture, 0},
-      std::pair{mask.Sheet.Texture, 2},
+      std::pair{texture, 0},
+      std::pair{maskTexture, 2},
   });
 
   // OK, all good, make quad
@@ -873,9 +949,12 @@ void Renderer::DrawCHLCCMenuBackground(const Sprite& sprite, const Sprite& mask,
 
   UseShader(*CHLCCMenuBackgroundShaderProgram, uniforms);
 
+  auto texture = UnwrapTextureId(sprite);
+  auto maskTexture = UnwrapTextureId(mask);
+
   UseTextures(std::array<std::pair<uint32_t, size_t>, 2>{
-      std::pair{sprite.Sheet.Texture, 0},
-      std::pair{mask.Sheet.Texture, 2},
+      std::pair{texture, 0},
+      std::pair{maskTexture, 2},
   });
 
   // OK, all good, make quad
@@ -906,8 +985,11 @@ void Renderer::DrawBlurredSprite(const Sprite& sprite, const CornersQuad& dest,
 
   UseShader(*GaussianBlurShaderProgram, uniforms);
 
+  auto texture = UnwrapTextureId(sprite);
+
   UseTextures(std::array<std::pair<uint32_t, size_t>, 1>{
-      std::pair{sprite.Sheet.Texture, 0}});
+      std::pair{texture, 0},
+  });
 
   // OK, all good, make quad
 
@@ -936,8 +1018,11 @@ void Renderer::DrawMosaic(const Sprite& sprite, const CornersQuad dest,
 
   UseShader(*MosaicShaderProgram, uniforms);
 
+  auto texture = UnwrapTextureId(sprite);
+
   UseTextures(std::array<std::pair<uint32_t, size_t>, 1>{
-      std::pair{sprite.Sheet.Texture, 0}});
+      std::pair{texture, 0},
+  });
 
   // OK, all good, make quad
 
@@ -1098,8 +1183,11 @@ void Renderer::DrawSubtitleGlyph(const Sprite& sprite, const CornersQuad& dest,
 
   UseShader(*SubtitleGlyphShaderProgram, uniforms);
 
+  auto texture = UnwrapTextureId(sprite);
+
   UseTextures(std::array<std::pair<uint32_t, size_t>, 1>{
-      std::pair{sprite.Sheet.Texture, 0}});
+      std::pair{texture, 0},
+  });
 
   // OK, all good, make quad
 
@@ -1214,6 +1302,21 @@ void Renderer::EnsureTopologyMode(TopologyMode newMode) {
     Flush();
     LastTopologyMode = newMode;
   }
+}
+
+uint32_t Renderer::UnwrapTextureId(Sprite const& sprite) {
+  return UnwrapTextureId(sprite.Sheet);
+}
+
+uint32_t Renderer::UnwrapTextureId(SpriteSheet const& sheet) {
+  if (!sheet.ScriptHandled) {
+    return sheet.Texture;
+  }
+  auto it = LookupTextureIdToTexture.find(sheet.Texture);
+  if (it == LookupTextureIdToTexture.end()) {
+    return 0;
+  }
+  return it->second;
 }
 
 }  // namespace OpenGL

--- a/src/renderer/opengl/renderer.h
+++ b/src/renderer/opengl/renderer.h
@@ -29,6 +29,9 @@ class Renderer : public BaseRenderer {
   void BeginFrame2D() override;
   void EndFrame() override;
 
+  uint32_t MapSpriteSheet(SpriteSheet const& sheet) override;
+  bool LoadSurf(int surfId, int archiveId, int fileId) override;
+  void UnloadSurf(int surfId) override;
   uint32_t SubmitTexture(TexFmt format, uint8_t* buffer, int width,
                          int height) override;
   int GetSpriteSheetImage(SpriteSheet const& sheet,
@@ -179,6 +182,8 @@ class Renderer : public BaseRenderer {
     InsertVerticesQuad(pos, uv, std::array{tint, tint, tint, tint}, maskUV);
   }
   void EnsureTopologyMode(TopologyMode newMode);
+  uint32_t UnwrapTextureId(Sprite const& sprite);
+  uint32_t UnwrapTextureId(SpriteSheet const& sheet);
 
   GLWindow* OpenGLWindow;
 

--- a/src/renderer/renderer.h
+++ b/src/renderer/renderer.h
@@ -76,6 +76,16 @@ class BaseRenderer {
   virtual void BeginFrame2D() = 0;
   virtual void EndFrame() = 0;
 
+  inline static ankerl::unordered_dense::map<
+      Io::AssetPath, uint32_t, Io::AssetPathHash, Io::AssetPathEqual>
+      SheetPathToId;
+  inline static ankerl::unordered_dense::map<uint32_t, uint32_t>
+      LookupTextureIdToTexture;
+  inline static ankerl::unordered_dense::map<int, Io::AssetPathKey> SurfToId;
+
+  virtual uint32_t MapSpriteSheet(SpriteSheet const& sheet) = 0;
+  virtual bool LoadSurf(int surfId, int archiveId, int fileId) = 0;
+  virtual void UnloadSurf(int surfId) = 0;
   virtual uint32_t SubmitTexture(TexFmt format, uint8_t* buffer, int width,
                                  int height) = 0;
 

--- a/src/renderer/vulkan/renderer.h
+++ b/src/renderer/vulkan/renderer.h
@@ -56,6 +56,11 @@ class Renderer : public BaseRenderer {
   void BeginFrame2D() override;
   void EndFrame() override;
 
+  uint32_t MapSpriteSheet(SpriteSheet const& sheet) override { return 0; };
+  bool LoadSurf(int surfId, int archiveId, int fileId) override {
+    return false;
+  };
+  void UnloadSurf(int surfId) override {};
   uint32_t SubmitTexture(TexFmt format, uint8_t* buffer, int width,
                          int height) override;
   int GetSpriteSheetImage(SpriteSheet const& sheet,

--- a/src/spritesheet.cpp
+++ b/src/spritesheet.cpp
@@ -1,0 +1,42 @@
+#include "spritesheet.h"
+#include "renderer/renderer.h"
+#include <mutex>
+#include <shared_mutex>
+
+namespace Impacto {
+
+static std::shared_mutex MapMutex;
+
+bool SpriteLoader::LoadSync(int surfId, int archiveId, int fileId) {
+  auto path = Io::AssetPathKey{.MountId = static_cast<uint32_t>(archiveId),
+                               .Id = static_cast<uint32_t>(fileId)};
+
+  auto innerTextureIdIter = Renderer->SheetPathToId.find(path);
+  if (innerTextureIdIter == Renderer->SheetPathToId.end()) {
+    return false;
+  }
+  InnerTextureId = innerTextureIdIter->second;
+
+  {
+    std::unique_lock writeLock(MapMutex);
+    Renderer->SurfToId.try_emplace(surfId, path);
+  }
+
+  Io::AssetPath pathRes = Io::AssetPathKey::KeyToAssetPath(path);
+  Io::Stream* stream;
+  IoError err = pathRes.Open(&stream);
+  if (err != IoError_OK) {
+    Window->Shutdown();
+  }
+
+  LoadedTexture.Load(stream);
+  delete stream;
+  return true;
+}
+
+void SpriteLoader::MainThreadOnLoad(bool result) {
+  if (!result) return;
+  Renderer->LookupTextureIdToTexture.try_emplace(InnerTextureId,
+                                                 LoadedTexture.Submit());
+}
+}  // namespace Impacto

--- a/src/spritesheet.h
+++ b/src/spritesheet.h
@@ -1,8 +1,25 @@
 ﻿#pragma once
 
 #include "util.h"
+#include "loadable.h"
+#include "io/assetpath.h"
+#include "texture/texture.h"
+
+#include <memory>
+#include <ankerl/unordered_dense.h>
 
 namespace Impacto {
+
+struct SpriteLoader : Loadable<SpriteLoader, bool, int, int, int> {
+  inline static ankerl::unordered_dense::map<int, SpriteLoader*> Sprites;
+
+  Texture LoadedTexture{};
+  uint32_t InnerTextureId;
+
+  bool LoadSync(int surfId, int archiveId, int fileId);
+  void UnloadSync() {}
+  void MainThreadOnLoad(bool result);
+};
 
 struct SpriteSheet {
   SpriteSheet() {}
@@ -13,8 +30,9 @@ struct SpriteSheet {
   float DesignHeight = 0;
 
   glm::vec2 GetDimensions() const { return {DesignWidth, DesignHeight}; }
-
+  Io::AssetPath Path{};
   uint32_t Texture = 0;
+  bool ScriptHandled = false;
   bool IsScreenCap = false;
 };
 

--- a/src/vm/inst_graphics2d.cpp
+++ b/src/vm/inst_graphics2d.cpp
@@ -40,6 +40,8 @@ VmInstruction(InstReleaseSurf) {
     if (Backgrounds2D[surfaceId]->Status == LoadStatus::Loaded) {
       Backgrounds2D[surfaceId]->Unload();
     }
+  } else {
+    Renderer->UnloadSurf(surfaceId);
   }
 }
 VmInstruction(InstLoadPic) {
@@ -51,21 +53,33 @@ VmInstruction(InstLoadPic) {
       LogLevel::Warning, LogChannel::VMStub,
       "STUB instruction LoadPic(surfaceId: {:d}, width: {:d}, height: {:d})\n",
       surfaceId, archiveId, fileId);
-  if (surfaceId < 8) {
-    switch (archiveId) {
-      case 0: {  // bg archive
-        if (Backgrounds2D[surfaceId]->Status == LoadStatus::Loading) {
-          ResetInstruction;
-          BlockThread;
-        } else if (ScrWork[SW_BG1NO + ScrWorkBgStructSize * surfaceId] !=
-                   fileId) {
-          ScrWork[SW_BG1NO + ScrWorkBgStructSize * surfaceId] = fileId;
-          Backgrounds2D[surfaceId]->LoadAsync(fileId);
-          ResetInstruction;
-          BlockThread;
-        }
-      } break;
-    }
+  switch (archiveId) {
+    case 0: {  // bg archive
+      if (Backgrounds2D[surfaceId]->Status == LoadStatus::Loading) {
+        ResetInstruction;
+        BlockThread;
+      } else if (ScrWork[SW_BG1NO + ScrWorkBgStructSize * surfaceId] !=
+                 fileId) {
+        ScrWork[SW_BG1NO + ScrWorkBgStructSize * surfaceId] = fileId;
+        Backgrounds2D[surfaceId]->LoadAsync(fileId);
+        ResetInstruction;
+        BlockThread;
+      }
+    } break;
+    case 2: {  // system
+      if (!SpriteLoader::Sprites.contains(surfaceId)) {
+        SpriteLoader::Sprites.emplace(surfaceId, new SpriteLoader());
+        SpriteLoader::Sprites[surfaceId]->LoadAsync(surfaceId, archiveId,
+                                                    fileId);
+        ResetInstruction;
+        BlockThread;
+      } else if (SpriteLoader::Sprites[surfaceId]->Status ==
+                 LoadStatus::Loading) {
+        ResetInstruction;
+        BlockThread;
+      }
+
+    } break;
   }
 }
 VmInstruction(InstSurfFill) {


### PR DESCRIPTION
- Allow sprite sheets to be loaded by the script, which offloads preloading them at the start of the game
- Speeds up Switch's start up time & eases RAM strain during start up ( sprite sheets need to be marked as `ScriptHandled = true` in the lua)