### PR TITLE
[CCLCC] Tips menu bugfixes.

### DIFF
--- a/profiles/cclcc/hud/tipsmenu.lua
+++ b/profiles/cclcc/hud/tipsmenu.lua
@@ -13,7 +13,8 @@ root.TipsMenu = {
     TipsNewSprite = "TipsNewSprite",
     TipsHighlightedSprite = "TipsHighlightedSprite",
 
-    TipsEntryBounds = { X = 80, Y = 382, Width = 781, Height = 50},
+    TipsEntryBounds = { X = 80, Y = 382, Width = 781, Height = 40},
+    TipsEntryYPadding = 10,
     TipEntryNewOffset = { X = 0, Y = 1 },
     TipsEntryHighlightOffset = { X = 41, Y = 3 },
     TipsEntryNumberOffset = { X = 41, Y = 12 },

--- a/src/profile/games/cclcc/tipsmenu.cpp
+++ b/src/profile/games/cclcc/tipsmenu.cpp
@@ -31,6 +31,7 @@ void Configure() {
   TipsTextPageHeight = EnsureGetMember<float>("TipsTextPageHeight");
 
   TipsEntryBounds = EnsureGetMember<RectF>("TipsEntryBounds");
+  TipsEntryYPadding = EnsureGetMember<float>("TipsEntryYPadding");
   TipEntryNewOffset = EnsureGetMember<glm::vec2>("TipEntryNewOffset");
   TipsEntryHighlightOffset =
       EnsureGetMember<glm::vec2>("TipsEntryHighlightOffset");

--- a/src/profile/games/cclcc/tipsmenu.h
+++ b/src/profile/games/cclcc/tipsmenu.h
@@ -21,6 +21,7 @@ inline int TipsTextEntryLockedIndex;
 inline float TipsTextPageHeight;
 
 inline RectF TipsEntryBounds;
+inline float TipsEntryYPadding;
 inline glm::vec2 TipEntryNewOffset;
 inline glm::vec2 TipsEntryNameOffset;
 inline glm::vec2 TipsEntryNumberOffset;

--- a/src/ui/widgets/cclcc/tipsentrybutton.cpp
+++ b/src/ui/widgets/cclcc/tipsentrybutton.cpp
@@ -75,7 +75,7 @@ void TipsEntryButton::Update(float dt) {
 }
 
 void TipsEntryButton::UpdateInput(float dt) {
-  if (TipsTabBounds.Intersects(Bounds) || TipsTabBounds.Contains(Bounds)) {
+  if (TipsTabBounds.Contains(Bounds)) {
     Button::UpdateInput(dt);
   } else {
     Hovered = false;

--- a/src/ui/widgets/cclcc/tipstabgroup.cpp
+++ b/src/ui/widgets/cclcc/tipstabgroup.cpp
@@ -69,8 +69,7 @@ TipsTabGroup::TipsTabGroup(
 
   TipsScrollTrackBounds = {TipsScrollThumbSprite.Bounds.Width,
                            TipsScrollYEnd - TipsScrollYStart};
-  EntriesPerPage =
-      (int)std::ceil(TipsTabBounds.Height / TipsEntryBounds.Height);
+  EntriesPerPage = (int)std::ceil(TipsTabBounds.Height / GetEntryStride());
 }
 
 void TipsTabGroup::UpdatePageInput(float dt) {
@@ -106,7 +105,7 @@ void TipsTabGroup::UpdatePageInput(float dt) {
           if (CurrentlyFocusedElement == TipsEntriesGroup.Children.front()) {
             ScrollPosY = 0;
           } else {
-            ScrollPosY += TipsEntryBounds.Height;
+            ScrollPosY += GetEntryStride();
           }
         }
       } else {
@@ -115,7 +114,7 @@ void TipsTabGroup::UpdatePageInput(float dt) {
           if (CurrentlyFocusedElement == TipsEntriesGroup.Children.back()) {
             ScrollPosY = TipsEntriesScrollbar->EndValue;
           } else {
-            ScrollPosY -= TipsEntryBounds.Height;
+            ScrollPosY -= GetEntryStride();
           }
         }
       }
@@ -131,7 +130,7 @@ void TipsTabGroup::UpdatePageInput(float dt) {
         AdvanceFocus(FDIR_RIGHT);
         if (CurrentlyFocusedElement != prevEntry) {
           if (checkScrollBounds())
-            ScrollPosY += TipsEntryBounds.Height * EntriesPerPage;
+            ScrollPosY += GetEntryStride() * EntriesPerPage;
         } else if (CurrentlyFocusedElement ==
                    TipsEntriesGroup.Children.back()) {
           CurrentlyFocusedElement->HasFocus = false;
@@ -152,7 +151,7 @@ void TipsTabGroup::UpdatePageInput(float dt) {
         AdvanceFocus(FDIR_LEFT);
         if (CurrentlyFocusedElement != prevEntry) {
           if (checkScrollBounds())
-            ScrollPosY -= TipsEntryBounds.Height * EntriesPerPage;
+            ScrollPosY -= GetEntryStride() * EntriesPerPage;
         } else if (CurrentlyFocusedElement ==
                    TipsEntriesGroup.Children.front()) {
           CurrentlyFocusedElement->HasFocus = false;
@@ -196,10 +195,10 @@ void TipsTabGroup::Update(float dt) {
       if (oldScrollPosY != ScrollPosY) {
         float delta = oldScrollPosY - ScrollPosY;
         // taken from CHLCC
-        if (std::fmod(std::abs(delta), TipsEntryBounds.Height) >
+        if (std::fmod(std::abs(delta), GetEntryStride()) >
             std::numeric_limits<float>::epsilon()) {
-          const float newDelta = std::round(delta / TipsEntryBounds.Height) *
-                                 TipsEntryBounds.Height;
+          const float newDelta =
+              std::round(delta / GetEntryStride()) * GetEntryStride();
           ScrollPosY = oldScrollPosY - newDelta;
           delta = newDelta;
         }
@@ -208,8 +207,7 @@ void TipsTabGroup::Update(float dt) {
         if (TipsEntriesScrollbar->IsScrollHeld() && CurrentlyFocusedElement) {
           // advance focus during drag
           FocusDirection dir = (delta < 0) ? FDIR_DOWN : FDIR_UP;
-          int steps =
-              static_cast<int>(std::abs(delta) / TipsEntryBounds.Height);
+          int steps = static_cast<int>(std::abs(delta) / GetEntryStride());
           for (int i = 0; i < steps; i++) {
             AdvanceFocus(dir);
           }
@@ -270,7 +268,7 @@ void TipsTabGroup::UpdateTipsEntries(std::vector<int> const& SortedTipIds) {
     }
     bool dispNew = record.IsNew && !record.IsLocked;
     RectF buttonBounds = TipsEntryBounds;
-    buttonBounds.Y += TipsEntryButtons.size() * buttonBounds.Height;
+    buttonBounds.Y += TipsEntryButtons.size() * GetEntryStride();
     TipsEntryButton* button = new TipsEntryButton(
         tipId, sortIndex++, buttonBounds, TipsHighlightedSprite, dispNew);
     button->OnClickHandler = TipClickHandler;
@@ -294,14 +292,14 @@ void TipsTabGroup::UpdateTipsEntries(std::vector<int> const& SortedTipIds) {
     return std::ceil(numToRound / multiple) * multiple;
   };
   int scrollDistance =
-      (int)(TipsEntryBounds.Height * TipsEntryButtons.size() -
-            roundUpMultiple(TipsTabBounds.Height, TipsEntryBounds.Height));
+      (int)(GetEntryStride() * TipsEntryButtons.size() -
+            roundUpMultiple(TipsTabBounds.Height, GetEntryStride()));
 
   TipsEntriesScrollbar = std::make_unique<Scrollbar>(
       0, TipsScrollStartPos, 0.0f, std::max(0.0f, (float)scrollDistance),
       &ScrollPosY, SBDIR_VERTICAL, TipsScrollThumbSprite, TipsScrollTrackBounds,
       TipsScrollThumbLength, TipsTabBounds);
-  TipsEntriesScrollbar->Step = TipsEntryBounds.Height;
+  TipsEntriesScrollbar->Step = GetEntryStride();
   TipsEntriesGroup.RenderingBounds = TipsTabBounds;
   TipsEntriesGroup.HoverBounds = TipsTabBounds;
   TabName.Reset();

--- a/src/ui/widgets/cclcc/tipstabgroup.h
+++ b/src/ui/widgets/cclcc/tipstabgroup.h
@@ -4,6 +4,7 @@
 #include "../group.h"
 #include "../../../data/tipssystem.h"
 #include "../../../games/cclcc/tipsmenu.h"
+#include "../../../profile/games/cclcc/tipsmenu.h"
 #include "tipsentrybutton.h"
 #include <vector>
 #include <memory>
@@ -40,6 +41,11 @@ class TipsTabGroup : public Menu {
   glm::vec4 Tint = glm::vec4(1.0f, 1.0f, 1.0f, 1.0f);
 
  private:
+  static float GetEntryStride() {
+    using namespace Impacto::Profile::CCLCC::TipsMenu;
+    return TipsEntryBounds.Height + TipsEntryYPadding;
+  }
+
   Widgets::Group TipsEntriesGroup;
   TipsTabButton TabName;
   Impacto::UI::CCLCC::TipsTabType Type;


### PR DESCRIPTION
This PR will fix (Screenshots were made before changes to show bugs in PR):

- Tip can be hovered even if can not see it.
<img width="838" height="107" alt="{BCE66071-8E5D-484E-B130-6AFB5AFD82E0}" src="https://github.com/user-attachments/assets/50ef811d-ef27-4712-8b32-a364ef54034d" />

- Tip highlight not reaching last visible Tip when holding/tapping (not fast) down with keyboard/gamepad.
<img width="879" height="709" alt="{8B9B44C8-4DC9-43F0-A213-BBF82532B181}" src="https://github.com/user-attachments/assets/085c4b00-5b77-452c-8fff-153fbb6c8325" />