### PR TITLE
[CCLCC] [CHLCC] Small Save/Quick Load/Load Menu changes.

### DIFF
--- a/src/data/savesystem.cpp
+++ b/src/data/savesystem.cpp
@@ -5,8 +5,10 @@
 #include "../profile/vm.h"
 #include "../mem.h"
 
+#include <algorithm>
 #include <cstdint>
 #include <ctime>
+#include <ranges>
 
 namespace Impacto {
 namespace SaveSystem {
@@ -283,6 +285,13 @@ std::optional<uint8_t> GetQuickSaveOpenSlot() {
   return std::nullopt;
 }
 
+int GetNewestSaveId(SaveType type) {
+  if (Implementation) return Implementation->GetNewestSaveId(type);
+  ImpLog(LogLevel::Warning, LogChannel::VMStub,
+         "{:s}: save system not implemented, returning 0\n", __func__);
+  return 0;
+}
+
 void UpdateQuickSaveRecentSortedId(int openSlot) {
   if (Implementation)
     return Implementation->UpdateQuickSaveRecentSortedId(openSlot);
@@ -350,6 +359,14 @@ std::optional<uint8_t> SaveSystemBase::GetQuickSaveOpenSlot() const {
   }
 
   return std::nullopt;
+}
+
+int SaveSystemBase::GetNewestSaveId(SaveType type) const {
+  const auto ids = std::views::iota(0, MaxSaveEntries);
+  return *std::ranges::min_element(
+      ids, SaveRecencyComparator(), [&](int id) -> SaveFileEntryBase const& {
+        return *GetSaveEntry<SaveFileEntryBase>(type, id);
+      });
 }
 
 void SaveSystemBase::UpdateQuickSaveRecentSortedId(int replacementSlot) {

--- a/src/data/savesystem.h
+++ b/src/data/savesystem.h
@@ -141,6 +141,7 @@ class SaveSystemBase {
   virtual void SetCheckpointId(int id) = 0;
   virtual Sprite& GetSaveThumbnail(SaveType type, int id) = 0;
   std::optional<uint8_t> GetQuickSaveOpenSlot() const;
+  int GetNewestSaveId(SaveType type) const;
   void UpdateQuickSaveRecentSortedId(int replacedSlot);
   Sprite& GetWorkingSaveThumbnail() { return WorkingSaveThumbnail; }
   int GetLockedQuickSaveCount() const;
@@ -211,6 +212,7 @@ bool GetBgmFlag(int id);
 void SetBgmFlag(int id, bool setFlag);
 void SetCheckpointId(int id);
 std::optional<uint8_t> GetQuickSaveOpenSlot();
+int GetNewestSaveId(SaveType type);
 void UpdateQuickSaveRecentSortedId(int replacedSlot);
 Sprite& GetSaveThumbnail(SaveType type, int id);
 Sprite& GetWorkingSaveThumbnail();

--- a/src/games/cclcc/savemenu.cpp
+++ b/src/games/cclcc/savemenu.cpp
@@ -173,8 +173,12 @@ void SaveMenu::Show() {
         }
       }
     }
+    const int newestSaveId = SaveSystem::GetNewestSaveId(saveType);
+    CurrentPage = newestSaveId / EntriesPerPage;
+    PrevPage = CurrentPage;
     MainItems[CurrentPage]->Show();
-    CurrentlyFocusedElement = MainItems[CurrentPage]->Children[0];
+    CurrentlyFocusedElement =
+        MainItems[CurrentPage]->Children[newestSaveId % EntriesPerPage];
     CurrentlyFocusedElement->HasFocus = true;
     if (UI::FocusedMenu != 0) {
       LastFocusedMenu = UI::FocusedMenu;
@@ -202,12 +206,14 @@ void SaveMenu::UpdateInput(float dt) {
   Menu::UpdateInput(dt);
   const auto updatePage = [&](int nextPage) {
     PrevPage = CurrentPage;
-    if (CurrentlyFocusedElement) {
-      CurrentlyFocusedElement->HasFocus = false;
-      CurrentlyFocusedElement->Hovered = false;
-    }
+    const int focusedEntry =
+        static_cast<Widgets::Button*>(CurrentlyFocusedElement)->Id %
+        EntriesPerPage;
+    CurrentlyFocusedElement->HasFocus = false;
+    CurrentlyFocusedElement->Hovered = false;
     CurrentPage = nextPage;
     MainItems[CurrentPage]->Show();
+    CurrentlyFocusedElement = MainItems[CurrentPage]->Children[focusedEntry];
     PageAnimation.StartIn();
     Audio::PlayInGroup(Audio::ACG_SE, "sysse", 1, false, 0);
   };
@@ -215,15 +221,14 @@ void SaveMenu::UpdateInput(float dt) {
     MainItems[CurrentPage]->UpdateInput(dt);
     if (Input::MouseWheelDeltaY < 0 || PADinputButtonWentDown & PADcustom[8]) {
       updatePage((CurrentPage + 1) % Pages);
-      CurrentlyFocusedElement = MainItems[CurrentPage]->GetFocus(FDIR_UP);
       IsFocused = false;
     } else if (Input::MouseWheelDeltaY > 0 ||
                PADinputButtonWentDown & PADcustom[7]) {
       updatePage((CurrentPage - 1 + Pages) % Pages);
-      CurrentlyFocusedElement = MainItems[CurrentPage]->GetFocus(FDIR_DOWN);
       IsFocused = false;
     } else {
-      if (PADinputButtonWentDown & (PAD1DOWN | PAD1UP | PAD1RIGHT | PAD1LEFT)) {
+      if (PADinputButtonRepeatAccelDown &
+          (PAD1DOWN | PAD1UP | PAD1RIGHT | PAD1LEFT)) {
         Audio::PlayInGroup(Audio::ACG_SE, "sysse", 1, false, 0);
       }
     }

--- a/src/games/chlcc/savemenu.cpp
+++ b/src/games/chlcc/savemenu.cpp
@@ -209,6 +209,8 @@ void SaveMenu::Show() {
       FromSystemMenuTransition->StartIn();
       SelectAnimation.StartIn(true);
     }
+    const int newestSaveId = SaveSystem::GetNewestSaveId(EntryType);
+    *CurrentPage = newestSaveId / EntriesPerPage;
     SavePages->at(*CurrentPage)->Show();
     SavePages->at(*CurrentPage)->HasFocus = false;
     State = Showing;
@@ -218,8 +220,9 @@ void SaveMenu::Show() {
     }
     IsFocused = true;
     UI::FocusedMenu = this;
-    SavePages->at(*CurrentPage)->Children.front()->HasFocus = true;
-    CurrentlyFocusedElement = SavePages->at(*CurrentPage)->Children.front();
+    CurrentlyFocusedElement =
+        SavePages->at(*CurrentPage)->Children[newestSaveId % EntriesPerPage];
+    CurrentlyFocusedElement->HasFocus = true;
   }
 }
 void SaveMenu::Hide() {
@@ -255,14 +258,16 @@ void SaveMenu::UpdateInput(float dt) {
   Menu::UpdateInput(dt);
   const auto updatePage = [&](int nextPage) {
     PrevPage = *CurrentPage;
-    if (CurrentlyFocusedElement) {
-      CurrentlyFocusedElement->HasFocus = false;
-      CurrentlyFocusedElement->Hovered = false;
-    }
+    const int focusedEntry =
+        static_cast<Widgets::Button*>(CurrentlyFocusedElement)->Id %
+        EntriesPerPage;
+    CurrentlyFocusedElement->HasFocus = false;
+    CurrentlyFocusedElement->Hovered = false;
     *CurrentPage = nextPage;
     SavePages->at(*CurrentPage)->Show();
-    SavePages->at(*CurrentPage)->Children.front()->HasFocus = true;
-    CurrentlyFocusedElement = SavePages->at(*CurrentPage)->Children.front();
+    CurrentlyFocusedElement =
+        SavePages->at(*CurrentPage)->Children[focusedEntry];
+    CurrentlyFocusedElement->HasFocus = true;
   };
   if (IsFocused) {
     SavePages->at(*CurrentPage)->UpdateInput(dt);

--- a/src/profile/games/cclcc/savemenu.h
+++ b/src/profile/games/cclcc/savemenu.h
@@ -27,6 +27,7 @@ inline glm::vec2 NoDataSpritePosition;
 
 int constexpr EntriesPerRow = 2;
 int constexpr RowsPerPage = 4;
+int constexpr EntriesPerPage = EntriesPerRow * RowsPerPage;
 inline uint32_t SaveEntryPrimaryColor;
 inline uint32_t LoadEntryPrimaryColor;
 inline uint32_t SaveEntrySecondaryColor;


### PR DESCRIPTION
This PR will:

- Make Save/Quick Load/Load Menu after changing page select last selected entry before changing page (similar to System Menu #320).
- Make Save/Quick Load/Load Menu highlight the newest entry every time the menu is opened.
- Make selecting sound (sysse id 1) play when holding keyboard/gamepad button in CCLCC Save/Quick Load/Load Menu.